### PR TITLE
Remove unnecessary else statements

### DIFF
--- a/cmd/dexctl/main.go
+++ b/cmd/dexctl/main.go
@@ -103,14 +103,14 @@ func getDriver() (drv driver) {
 	case len(global.endpoint) > 0:
 		if len(global.creds.ID) == 0 || len(global.creds.Secret) == 0 {
 			err = errors.New("--client-id/--client-secret flags unset")
-		} else {
-			pcfg, err := oidc.FetchProviderConfig(http.DefaultClient, global.endpoint)
-			if err != nil {
-				stderr("Unable to fetch provider config: %v", err)
-				os.Exit(1)
-			}
-			drv, err = newAPIDriver(pcfg, global.creds)
+			break
 		}
+		pcfg, err := oidc.FetchProviderConfig(http.DefaultClient, global.endpoint)
+		if err != nil {
+			stderr("Unable to fetch provider config: %v", err)
+			os.Exit(1)
+		}
+		drv, err = newAPIDriver(pcfg, global.creds)
 	default:
 		err = errors.New("--endpoint/--db-url flags unset")
 	}

--- a/db/gc.go
+++ b/db/gc.go
@@ -66,11 +66,11 @@ func (gc *GarbageCollector) Run() chan struct{} {
 						next = ptime.ExpBackoff(next, time.Minute)
 					}
 					log.Errorf("Failed garbage collection, retrying in %v", next)
-				} else {
-					failing = false
-					next = gc.interval
-					log.Infof("Garbage collection complete, running again in %v", next)
+					break
 				}
+				failing = false
+				next = gc.interval
+				log.Infof("Garbage collection complete, running again in %v", next)
 			case <-stop:
 				return
 			}

--- a/db/password.go
+++ b/db/password.go
@@ -49,12 +49,11 @@ func (r *passwordInfoRepo) Create(tx repo.Transaction, pw user.PasswordInfo) (er
 	}
 
 	_, err = r.get(tx, pw.UserID)
-	if err != nil {
-		if err != user.ErrorNotFound {
-			return err
-		}
-	} else {
+	if err == nil {
 		return user.ErrorDuplicateID
+	}
+	if err != user.ErrorNotFound {
+		return err
 	}
 
 	err = r.insert(tx, pw)

--- a/db/user.go
+++ b/db/user.go
@@ -76,12 +76,11 @@ func (r *userRepo) Create(tx repo.Transaction, usr user.User) (err error) {
 	}
 
 	_, err = r.get(tx, usr.ID)
-	if err != nil {
-		if err != user.ErrorNotFound {
-			return err
-		}
-	} else {
+	if err == nil {
 		return user.ErrorDuplicateID
+	}
+	if err != user.ErrorNotFound {
+		return err
 	}
 
 	if !user.ValidEmail(usr.Email) {
@@ -90,12 +89,11 @@ func (r *userRepo) Create(tx repo.Transaction, usr user.User) (err error) {
 
 	// make sure there's no other user with the same Email
 	_, err = r.getByEmail(tx, usr.Email)
-	if err != nil {
-		if err != user.ErrorNotFound {
-			return err
-		}
-	} else {
+	if err == nil {
 		return user.ErrorDuplicateEmail
+	}
+	if err != user.ErrorNotFound {
+		return err
 	}
 
 	err = r.insert(tx, usr)

--- a/pkg/crypto/rand.go
+++ b/pkg/crypto/rand.go
@@ -10,7 +10,8 @@ func RandBytes(n int) ([]byte, error) {
 	got, err := rand.Read(b)
 	if err != nil {
 		return nil, err
-	} else if n != got {
+	}
+	if n != got {
 		return nil, errors.New("unable to generate enough random data")
 	}
 	return b, nil

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -39,7 +39,8 @@ func (rr *RequestRecorder) Do(req *http.Request) (*http.Response, error) {
 
 	if rr.Response == nil && rr.Error == nil {
 		panic("RequestRecorder Response and Error cannot both be nil")
-	} else if rr.Response != nil && rr.Error != nil {
+	}
+	if rr.Response != nil && rr.Error != nil {
 		panic("RequestRecorder Response and Error cannot both be non-nil")
 	}
 

--- a/refresh/repo.go
+++ b/refresh/repo.go
@@ -33,7 +33,8 @@ func DefaultRefreshTokenGenerator() ([]byte, error) {
 	n, err := rand.Read(b)
 	if err != nil {
 		return nil, err
-	} else if n != DefaultRefreshTokenPayloadLength {
+	}
+	if n != DefaultRefreshTokenPayloadLength {
 		return nil, errors.New("unable to read enough random bytes")
 	}
 	return b, nil

--- a/server/auth_middleware.go
+++ b/server/auth_middleware.go
@@ -56,7 +56,8 @@ func (c *clientTokenMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request
 		writeAPIError(w, http.StatusUnauthorized, newAPIError(errorAccessDenied, ""))
 		respondError()
 		return
-	} else if len(keys) == 0 {
+	}
+	if len(keys) == 0 {
 		log.Error("No keys available for verification in client token middleware")
 		writeAPIError(w, http.StatusUnauthorized, newAPIError(errorAccessDenied, ""))
 		respondError()
@@ -68,7 +69,8 @@ func (c *clientTokenMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request
 		log.Errorf("Failed to verify signature: %v", err)
 		respondError()
 		return
-	} else if !ok {
+	}
+	if !ok {
 		log.Info("Invalid token")
 		respondError()
 		return
@@ -112,7 +114,8 @@ func getClientIDFromAuthorizedRequest(r *http.Request) (string, error) {
 	sub, ok, err := claims.StringClaim("sub")
 	if err != nil {
 		return "", fmt.Errorf("failed to parse 'sub' claim: %v", err)
-	} else if !ok || sub == "" {
+	}
+	if !ok || sub == "" {
 		return "", errors.New("missing required 'sub' claim")
 	}
 

--- a/server/http.go
+++ b/server/http.go
@@ -185,7 +185,8 @@ func renderLoginPage(w http.ResponseWriter, r *http.Request, srv OIDCServer, idp
 		td.Message = "Server Error"
 		execTemplate(w, tpl, td)
 		return
-	} else if cm == nil {
+	}
+	if cm == nil {
 		td.Error = true
 		td.Message = "Authentication Error"
 		td.Detail = "Invalid client ID"

--- a/server/register.go
+++ b/server/register.go
@@ -183,14 +183,13 @@ func handleRegisterFunc(s *Server) http.HandlerFunc {
 				data.FormErrors = formErrors
 				execTemplate(w, tpl, data)
 				return
-			} else {
-				if err == user.ErrorDuplicateRemoteIdentity {
-					errPage(w, "You already registered an account with this identity", "", http.StatusConflict)
-					return
-				}
-				internalError(w, err)
+			}
+			if err == user.ErrorDuplicateRemoteIdentity {
+				errPage(w, "You already registered an account with this identity", "", http.StatusConflict)
 				return
 			}
+			internalError(w, err)
+			return
 		}
 		ses, err = s.SessionManager.AttachUser(sessionID, userID)
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -351,7 +351,8 @@ func (s *Server) ClientCredsToken(creds oidc.ClientCredentials) (*jose.JWT, erro
 	if err != nil {
 		log.Errorf("Failed fetching client %s from repo: %v", creds.ID, err)
 		return nil, oauth2.NewError(oauth2.ErrorServerError)
-	} else if !ok {
+	}
+	if !ok {
 		return nil, oauth2.NewError(oauth2.ErrorInvalidClient)
 	}
 
@@ -382,7 +383,8 @@ func (s *Server) CodeToken(creds oidc.ClientCredentials, sessionKey string) (*jo
 	if err != nil {
 		log.Errorf("Failed fetching client %s from repo: %v", creds.ID, err)
 		return nil, "", oauth2.NewError(oauth2.ErrorServerError)
-	} else if !ok {
+	}
+	if !ok {
 		log.Errorf("Failed to Authenticate client %s", creds.ID)
 		return nil, "", oauth2.NewError(oauth2.ErrorInvalidClient)
 	}
@@ -450,7 +452,8 @@ func (s *Server) RefreshToken(creds oidc.ClientCredentials, token string) (*jose
 	if err != nil {
 		log.Errorf("Failed fetching client %s from repo: %v", creds.ID, err)
 		return nil, oauth2.NewError(oauth2.ErrorServerError)
-	} else if !ok {
+	}
+	if !ok {
 		log.Errorf("Failed to Authenticate client %s", creds.ID)
 		return nil, oauth2.NewError(oauth2.ErrorInvalidClient)
 	}

--- a/session/manager.go
+++ b/session/manager.go
@@ -20,7 +20,8 @@ func DefaultGenerateCode() (string, error) {
 	n, err := rand.Read(b)
 	if err != nil {
 		return "", err
-	} else if n != 8 {
+	}
+	if n != 8 {
 		return "", errors.New("unable to read enough random bytes")
 	}
 	return base64.URLEncoding.EncodeToString(b), nil

--- a/user/api/api.go
+++ b/user/api/api.go
@@ -233,7 +233,8 @@ func generateTempHash() (string, error) {
 	n, err := rand.Read(b)
 	if err != nil {
 		return "", err
-	} else if n != 32 {
+	}
+	if n != 32 {
 		return "", errors.New("unable to read enough random bytes")
 	}
 	return base64.URLEncoding.EncodeToString(b), nil

--- a/user/password.go
+++ b/user/password.go
@@ -169,12 +169,13 @@ func (u *PasswordInfo) UnmarshalJSON(data []byte) error {
 			return ErrorInvalidPassword
 		}
 		u.Password = Password(dec.PasswordHash)
-	} else if dec.PasswordPlaintext != "" {
+		return nil
+	}
+	if dec.PasswordPlaintext != "" {
 		u.Password, err = NewPasswordFromPlaintext(dec.PasswordPlaintext)
 		if err != nil {
 			return err
 		}
-
 	}
 	return nil
 }


### PR DESCRIPTION
Whenever it makes the code easier to follow, use early return to
avoid else statements.

It's a dirty job, but someone has to do it.