### PR TITLE
Documentation: no need to create a new Google project

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -18,7 +18,7 @@ Before continuing, you must have the following installed on your system:
 
 In addition, if you wish to try out authenticating against Google's OIDC backend, you must have a new client registered with Google:
 
-* Go to https://console.developers.google.com/project and create a new project.
+* Go to https://console.developers.google.com/project and select an existing project or create a new project.
 * Click on credentials, and ask to set up an OAuth 2 client ID. You'll then need to give your project a name.
 * Back at the "Create Client ID" screen, choose "Web Application" and enter `http://127.0.0.1:5556/auth/google/callback` for your Redirect URI.
 


### PR DESCRIPTION
A new API key can be generated in an existing Google project

Fixes #123

Signed-off-by: Chris Swan <@cpswan>