### PR TITLE
Documentation: clearer guidance on creating OAuth 2 client ID

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -19,8 +19,9 @@ Before continuing, you must have the following installed on your system:
 In addition, if you wish to try out authenticating against Google's OIDC backend, you must have a new client registered with Google:
 
 * Go to https://console.developers.google.com/project and select an existing project or create a new project.
-* Click on credentials, and ask to set up an OAuth 2 client ID. You'll then need to give your project a name.
-* Back at the "Create Client ID" screen, choose "Web Application" and enter `http://127.0.0.1:5556/auth/google/callback` for your Redirect URI.
+* Click on APIs and auth > Credentials, and select an OAuth 2 client ID from the Add credentials dropdown.
+* On the "Create Client ID" screen, choose "Web Application", provide a Name and enter `http://127.0.0.1:5556/auth/google/callback` for your Authorised redirect URI.
+* The generated client ID and client secret will be needed later.
 
 # Create Database
 


### PR DESCRIPTION
Provides a more accurate walk through of the screens and menus of the Google
Developers Console encountered whilst creating a client ID.

Fixes #125

Signed-off-by: Chris Swan <@cpswan>