### PR TITLE
cmd/dex-worker: wait 'til connectors are available

### DIFF
--- a/cmd/dex-worker/main.go
+++ b/cmd/dex-worker/main.go
@@ -7,14 +7,16 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/gorilla/handlers"
 
+	"github.com/coreos/dex/connector"
 	"github.com/coreos/dex/db"
 	pflag "github.com/coreos/dex/pkg/flag"
 	"github.com/coreos/dex/pkg/log"
+	ptime "github.com/coreos/dex/pkg/time"
 	"github.com/coreos/dex/server"
-
 	"github.com/coreos/pkg/flagutil"
 )
 
@@ -150,9 +152,21 @@ func main() {
 		log.Fatalf("Unable to build Server: %v", err)
 	}
 
-	cfgs, err := srv.ConnectorConfigRepo.All()
-	if err != nil {
-		log.Fatalf("Unable to fetch connector configs from repo: %v", err)
+	var cfgs []connector.ConnectorConfig
+	var sleep time.Duration
+	for {
+		var err error
+		cfgs, err = srv.ConnectorConfigRepo.All()
+		if len(cfgs) > 0 && err == nil {
+			break
+		}
+		sleep = ptime.ExpBackoff(sleep, time.Minute)
+		if err != nil {
+			log.Errorf("Unable to load connectors, retrying in %v: %v", sleep, err)
+		} else {
+			log.Errorf("No connectors, will wait. Retrying in %v.", sleep)
+		}
+		time.Sleep(sleep)
 	}
 
 	for _, cfg := range cfgs {

--- a/cmd/dex-worker/main.go
+++ b/cmd/dex-worker/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/coreos/pkg/flagutil"
 	"github.com/gorilla/handlers"
 
 	"github.com/coreos/dex/connector"
@@ -17,7 +18,6 @@ import (
 	"github.com/coreos/dex/pkg/log"
 	ptime "github.com/coreos/dex/pkg/time"
 	"github.com/coreos/dex/server"
-	"github.com/coreos/pkg/flagutil"
 )
 
 var version = "DEV"


### PR DESCRIPTION
Otherwise, if worker starts without connectors, and then connectors are
added workers have to be restarted to pick up the changes.