### PR TITLE
server: use routable url for user creation

### DIFF
--- a/server/user.go
+++ b/server/user.go
@@ -25,7 +25,7 @@ const (
 var (
 	UsersSubTree        = "/users"
 	UsersListEndpoint   = addBasePath(UsersSubTree) + "/"
-	UsersCreateEndooint = addBasePath(UsersSubTree)
+	UsersCreateEndpoint = addBasePath(UsersSubTree) + "/"
 	UsersGetEndpoint    = addBasePath(UsersSubTree + "/:id")
 )
 
@@ -48,7 +48,7 @@ func NewUserMgmtServer(userMgmtAPI *api.UsersAPI, jwtvFactory JWTVerifierFactory
 func (s *UserMgmtServer) HTTPHandler() http.Handler {
 	r := httprouter.New()
 	r.GET(UsersListEndpoint, s.listUsers)
-	r.POST(UsersCreateEndooint, s.createUser)
+	r.POST(UsersCreateEndpoint, s.createUser)
 	r.GET(UsersGetEndpoint, s.getUser)
 	return r
 }


### PR DESCRIPTION
Our httprouter cleans up routes that appear to be missing a trailing slash by redirecting clients. That means that the url `*/users` cannot be hit, since there is a live `*/users/` url - the router will always redirect the url without the slash. This pull request  attempts to avoid the issue by moving the endpoint.