### PR TITLE
server: user management endpoints strictly conform to schema

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -244,7 +244,7 @@ func (s *Server) HTTPHandler() http.Handler {
 	mux.Handle(path.Join(apiBasePath, clientPath), s.NewClientTokenAuthHandler(clientHandler))
 
 	usersAPI := usersapi.NewUsersAPI(s.UserManager, s.ClientIdentityRepo, s.UserEmailer, s.localConnectorID)
-	mux.Handle(path.Join(apiBasePath, UsersSubTree)+"/", NewUserMgmtServer(usersAPI, s.JWTVerifierFactory(), s.UserManager, s.ClientIdentityRepo).HTTPHandler())
+	mux.Handle(path.Join(apiBasePath, UsersSubTree), NewUserMgmtServer(usersAPI, s.JWTVerifierFactory(), s.UserManager, s.ClientIdentityRepo).HTTPHandler())
 
 	return http.Handler(mux)
 }

--- a/server/user.go
+++ b/server/user.go
@@ -24,8 +24,8 @@ const (
 
 var (
 	UsersSubTree        = "/users"
-	UsersListEndpoint   = addBasePath(UsersSubTree) + "/"
-	UsersCreateEndooint = addBasePath(UsersSubTree)
+	UsersListEndpoint   = addBasePath(UsersSubTree)
+	UsersCreateEndpoint = addBasePath(UsersSubTree)
 	UsersGetEndpoint    = addBasePath(UsersSubTree + "/:id")
 )
 
@@ -47,8 +47,10 @@ func NewUserMgmtServer(userMgmtAPI *api.UsersAPI, jwtvFactory JWTVerifierFactory
 
 func (s *UserMgmtServer) HTTPHandler() http.Handler {
 	r := httprouter.New()
+	r.RedirectTrailingSlash = false
+	r.RedirectFixedPath = false
 	r.GET(UsersListEndpoint, s.listUsers)
-	r.POST(UsersCreateEndooint, s.createUser)
+	r.POST(UsersCreateEndpoint, s.createUser)
 	r.GET(UsersGetEndpoint, s.getUser)
 	return r
 }


### PR DESCRIPTION
This change disables the URL fixing behavior or the router associated
with the user management schema. After this commit, URLS routing
to /api/$VERSION/users must target exactly the specified paths. In
addition, `/api/$VERSION/users/` will serve a 404

This change allows users to hit the user create endpoint, which
would previously serve a redirect rather than actually making the
associated change.