### PR TITLE
build: add equals sign to avoid link warning when building project

### DIFF
--- a/build
+++ b/build
@@ -22,7 +22,7 @@ rm -rf $GOPATH/src/github.com/coreos/dex
 mkdir -p $GOPATH/src/github.com/coreos/
 ln -s ${PWD} $GOPATH/src/github.com/coreos/dex
 
-LD_FLAGS="-X main.version $(git rev-parse HEAD)"
+LD_FLAGS="-X main.version=$(git rev-parse HEAD)"
 go build -o bin/dex-worker -ldflags="$LD_FLAGS" github.com/coreos/dex/cmd/dex-worker
 go build -o bin/dexctl github.com/coreos/dex/cmd/dexctl
 go build -o bin/dex-overlord -ldflags="$LD_FLAGS" github.com/coreos/dex/cmd/dex-overlord


### PR DESCRIPTION
With `go version go1.5.1 darwin/amd64`, I was getting the following warning twice when building:

```
link: warning: option -X main.version 6970b481f4d8c6b65d72e6bd9000340fa934187b may not work in future releases; use -X main.version=6970b481f4d8c6b65d72e6bd9000340fa934187b
```

This modification adds the "=" sign (as directed) and prevents the warning.