### PR TITLE
db: log schema errors, distinguish them from nil results where needed

### DIFF
--- a/db/client.go
+++ b/db/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"reflect"
 
 	"github.com/coreos/go-oidc/oidc"
 	"github.com/go-gorp/gorp"
@@ -163,6 +164,7 @@ func (r *clientIdentityRepo) Metadata(clientID string) (*oidc.ClientMetadata, er
 
 	cim, ok := m.(*clientIdentityModel)
 	if !ok {
+		log.Errorf("expected clientIdentityModel but found %v", reflect.TypeOf(m))
 		return nil, errors.New("unrecognized model")
 	}
 
@@ -182,6 +184,7 @@ func (r *clientIdentityRepo) IsDexAdmin(clientID string) (bool, error) {
 
 	cim, ok := m.(*clientIdentityModel)
 	if !ok {
+		log.Errorf("expected clientIdentityModel but found %v", reflect.TypeOf(m))
 		return false, errors.New("unrecognized model")
 	}
 
@@ -203,6 +206,7 @@ func (r *clientIdentityRepo) SetDexAdmin(clientID string, isAdmin bool) error {
 	cim, ok := m.(*clientIdentityModel)
 	if !ok {
 		rollback(tx)
+		log.Errorf("expected clientIdentityModel but found %v", reflect.TypeOf(m))
 		return errors.New("unrecognized model")
 	}
 
@@ -230,6 +234,7 @@ func (r *clientIdentityRepo) Authenticate(creds oidc.ClientCredentials) (bool, e
 
 	cim, ok := m.(*clientIdentityModel)
 	if !ok {
+		log.Errorf("expected clientIdentityModel but found %v", reflect.TypeOf(m))
 		return false, errors.New("unrecognized model")
 	}
 

--- a/db/password.go
+++ b/db/password.go
@@ -2,8 +2,10 @@ package db
 
 import (
 	"errors"
+	"reflect"
 	"time"
 
+	"github.com/coreos/dex/pkg/log"
 	"github.com/coreos/dex/repo"
 	"github.com/coreos/dex/user"
 	"github.com/go-gorp/gorp"
@@ -113,6 +115,7 @@ func (r *passwordInfoRepo) get(tx repo.Transaction, id string) (user.PasswordInf
 
 	pwm, ok := m.(*passwordInfoModel)
 	if !ok {
+		log.Errorf("expected passwordInfoModel but found %v", reflect.TypeOf(m))
 		return user.PasswordInfo{}, errors.New("unrecognized model")
 	}
 

--- a/db/refresh.go
+++ b/db/refresh.go
@@ -4,9 +4,11 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
+	"github.com/coreos/dex/pkg/log"
 	"github.com/coreos/dex/refresh"
 	"github.com/go-gorp/gorp"
 	"golang.org/x/crypto/bcrypt"
@@ -185,6 +187,7 @@ func (r *refreshTokenRepo) get(tx *gorp.Transaction, tokenID int64) (*refreshTok
 
 	record, ok := result.(*refreshTokenModel)
 	if !ok {
+		log.Errorf("expected refreshTokenModel but found %v", reflect.TypeOf(result))
 		return nil, errors.New("unrecognized model")
 	}
 	return record, nil

--- a/db/session.go
+++ b/db/session.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
 
@@ -137,8 +138,13 @@ func (r *SessionRepo) Get(sessionID string) (*session.Session, error) {
 		return nil, err
 	}
 
+	if m == nil {
+		return nil, errors.New("session does not exist")
+	}
+
 	sm, ok := m.(*sessionModel)
 	if !ok {
+		log.Errorf("expected sessionModel but found %v", reflect.TypeOf(m))
 		return nil, errors.New("unrecognized model")
 	}
 

--- a/db/session_key.go
+++ b/db/session_key.go
@@ -3,6 +3,7 @@ package db
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/go-gorp/gorp"
@@ -62,8 +63,13 @@ func (r *SessionKeyRepo) Pop(key string) (string, error) {
 		return "", err
 	}
 
+	if m == nil {
+		return "", errors.New("session key does not exist")
+	}
+
 	skm, ok := m.(*sessionKeyModel)
 	if !ok {
+		log.Errorf("expected sessionKeyModel but found %v", reflect.TypeOf(m))
 		return "", errors.New("unrecognized model")
 	}
 

--- a/db/user.go
+++ b/db/user.go
@@ -4,11 +4,13 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/go-gorp/gorp"
 	"github.com/lib/pq"
 
+	"github.com/coreos/dex/pkg/log"
 	"github.com/coreos/dex/repo"
 	"github.com/coreos/dex/user"
 )
@@ -257,6 +259,7 @@ func (r *userRepo) GetRemoteIdentities(tx repo.Transaction, userID string) ([]us
 	for _, m := range rims {
 		rim, ok := m.(*remoteIdentityMappingModel)
 		if !ok {
+			log.Errorf("expected remoteIdentityMappingModel but found %v", reflect.TypeOf(m))
 			return nil, errors.New("unrecognized model")
 		}
 
@@ -313,6 +316,7 @@ func (r *userRepo) List(tx repo.Transaction, filter user.UserFilter, maxResults 
 	for i := 0; i < numUsers; i++ {
 		um, ok := ums[i].(*userModel)
 		if !ok {
+			log.Errorf("expected userModel but found %v", reflect.TypeOf(ums[i]))
 			return nil, "", errors.New("unrecognized model")
 		}
 		usr, err := um.user()
@@ -379,6 +383,7 @@ func (r *userRepo) get(tx repo.Transaction, userID string) (user.User, error) {
 
 	um, ok := m.(*userModel)
 	if !ok {
+		log.Errorf("expected userModel but found %v", reflect.TypeOf(m))
 		return user.User{}, errors.New("unrecognized model")
 	}
 
@@ -399,6 +404,7 @@ func (r *userRepo) getUserIDForRemoteIdentity(tx repo.Transaction, ri user.Remot
 
 	rim, ok := m.(*remoteIdentityMappingModel)
 	if !ok {
+		log.Errorf("expected remoteIdentityMappingModel but found %v", reflect.TypeOf(m))
 		return "", errors.New("unrecognized model")
 	}
 


### PR DESCRIPTION
gorp schema errors are a big deal, and probably worth some log information. This PRQ also changes the error protocol of some DB functions to distinguish between nil (which seems like a common thing) and type assertion failures (which are super scary)