### PR TITLE
Protect admin api

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -45,17 +45,24 @@ dex needs a 32 byte base64-encoded key which will be used to encrypt the private
 
 The dex overlord and workers allow multiple key secrets (separated by commas) to be passed but only the first will be used to encrypt data; the rest are there for decryption only; this scheme allows for the rotation of keys without downtime (assuming a rolling restart of workers).
 
+# Generate an Admin API Secret
+
+The dex overlord has a an API which is very powerful - you can create Admin users with it, so it needs to be protected somehow. This is accomplished by requiring that a secret is passed via the Authorization header of each request. This secret is 128 bytes base64 encoded, and should be sufficiently random so as to make guessing impractical:
+
+`DEX_OVERLORD_ADMIN_API_SECRET=$(dd if=/dev/random bs=1 count=128 2>/dev/null | base64)`
+
 # Start the overlord
 
 The overlord is responsible for creating and rotating keys and some other adminsitrative tasks. In addition, the overlord is responsible for creating the necessary database tables (and when you update, performing schema migrations), so it must be started before we do anything else. Debug logging is turned on so we can see more of what's going on. Start it up.
 
-`./bin/dex-overlord --db-url=$DEX_DB_URL --key-secrets=$DEX_KEY_SECRET --log-debug=true &`
+`./bin/dex-overlord --admin-api-secret=$DEX_OVERLORD_ADMIN_API_SECRET --db-url=$DEX_DB_URL --key-secrets=$DEX_KEY_SECRET --log-debug=true &`
 
 ## Environment Variables.
 
 Note that parameters can be passed as flags or environment variables to dex components; an equivalent start with environment variables would be:
 
 ```
+export DEX_OVERLORD_ADMIN_API_SECRET=$DEX_OVERLORD_ADMIN_API_SECRET
 export DEX_OVERLORD_DB_URL=$DEX_DB_URL
 export DEX_OVERLORD_KEY_SECRETS=$DEX_KEY_SECRET
 export DEX_OVERLORD_LOG_DEBUG=true

--- a/cmd/dex-overlord/main.go
+++ b/cmd/dex-overlord/main.go
@@ -41,6 +41,9 @@ func main() {
 
 	adminListen := fs.String("admin-listen", "http://127.0.0.1:5557", "scheme, host and port for listening for administrative operation requests ")
 
+	adminAPISecret := pflag.NewBase64(server.AdminAPISecretLength)
+	fs.Var(adminAPISecret, "admin-api-secret", fmt.Sprintf("A base64-encoded %d byte string which is used to protect the Admin API.", server.AdminAPISecretLength))
+
 	localConnectorID := fs.String("local-connector", "local", "ID of the local connector")
 	logDebug := fs.Bool("log-debug", false, "log debug-level information")
 	logTimestamps := fs.Bool("log-timestamps", false, "prefix log lines with timestamps")
@@ -124,7 +127,7 @@ func main() {
 	}
 
 	krot := key.NewPrivateKeyRotator(kRepo, *keyPeriod)
-	s := server.NewAdminServer(adminAPI, krot)
+	s := server.NewAdminServer(adminAPI, krot, adminAPISecret.String())
 	h := s.HTTPHandler()
 	httpsrv := &http.Server{
 		Addr:    adminURL.Host,

--- a/contrib/standup-db.sh
+++ b/contrib/standup-db.sh
@@ -31,6 +31,7 @@ DEX_KEY_SECRET=$(dd if=/dev/random bs=1 count=32 2>/dev/null | base64)
 export DEX_OVERLORD_DB_URL=$DEX_DB_URL
 export DEX_OVERLORD_KEY_SECRETS=$DEX_KEY_SECRET
 export DEX_OVERLORD_KEY_PERIOD=1h
+export DEX_OVERLORD_ADMIN_API_SECRET=$(dd if=/dev/random bs=1 count=128 2>/dev/null | base64)
 ./bin/dex-overlord &
 echo "Waiting for overlord to start..."
 until $(curl --output /dev/null --silent --fail http://localhost:5557/health); do
@@ -79,5 +80,5 @@ done
 ./bin/example-app --client-id=$DEX_APP_CLIENT_ID --client-secret=$DEX_APP_CLIENT_SECRET --discovery=http://127.0.0.1:5556 &
 
 # Create Admin User - the password is a hash of the word "password"
-curl -X POST --data '{"email":"admin@example.com","password":"$2a$04$J54iz31fhYfXIRVglUMmpufY6TKf/vvwc9pv8zWog7X/LFrFfkNQe" }' http://127.0.0.1:5557/api/v1/admin
+curl -X POST --data '{"email":"admin@example.com","password":"$2a$04$J54iz31fhYfXIRVglUMmpufY6TKf/vvwc9pv8zWog7X/LFrFfkNQe" }' --header "Authorization: $DEX_OVERLORD_ADMIN_API_SECRET" http://127.0.0.1:5557/api/v1/admin
 


### PR DESCRIPTION
Requests made to admin API must have an `Authorization` header with 128 bytes encoded base64