### PR TITLE
email: allow no emailer

### DIFF
--- a/email/template.go
+++ b/email/template.go
@@ -24,6 +24,9 @@ func NewTemplatizedEmailerFromGlobs(textGlob, htmlGlob string, emailer Emailer) 
 
 // NewTemplatizedEmailerFromTemplates creates a new TemplatizedEmailer, given root text and html templates.
 func NewTemplatizedEmailerFromTemplates(textTemplates *template.Template, htmlTemplates *htmltemplate.Template, emailer Emailer) *TemplatizedEmailer {
+	if emailer == nil {
+		return nil
+	}
 	return &TemplatizedEmailer{
 		emailer:       emailer,
 		textTemplates: textTemplates,


### PR DESCRIPTION
These are a set of commits that will allow dex-worker to run without an emailer. The issue came up because currently there is no way to receive a resetPasswordURL when creating a user. We should probably either merge something like this PRQ, or revisit the code at https://github.com/coreos/dex/blob/master/user/api/api.go#L172