### PR TITLE
server: use standard lib http.Request.BasicAuth

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -27,30 +26,6 @@ func WriteError(w http.ResponseWriter, code int, msg string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	w.Write(b)
-}
-
-// BasicAuth parses a username and password from the request's
-// Authorization header. This was pulled from golang master:
-// https://codereview.appspot.com/76540043
-func BasicAuth(r *http.Request) (username, password string, ok bool) {
-	auth := r.Header.Get("Authorization")
-	if auth == "" {
-		return
-	}
-
-	if !strings.HasPrefix(auth, "Basic ") {
-		return
-	}
-	c, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic "))
-	if err != nil {
-		return
-	}
-	cs := string(c)
-	s := strings.IndexByte(cs, ':')
-	if s < 0 {
-		return
-	}
-	return cs[:s], cs[s+1:], true
 }
 
 func cacheControlMaxAge(hdr string) (time.Duration, bool, error) {

--- a/server/http.go
+++ b/server/http.go
@@ -418,7 +418,7 @@ func handleTokenFunc(srv OIDCServer) http.HandlerFunc {
 
 		state := r.PostForm.Get("state")
 
-		user, password, ok := phttp.BasicAuth(r)
+		user, password, ok := r.BasicAuth()
 		if !ok {
 			log.Errorf("error parsing basic auth")
 			writeTokenError(w, oauth2.NewError(oauth2.ErrorInvalidClient), state)


### PR DESCRIPTION
Go 1.4+ has https://golang.org/pkg/net/http/#Request.BasicAuth
method for http.Request and it was requested by CoreOS(kelsey) [1]
with the same functionalities. If dex's Go development is being done
in Go 1.4 or later, we should use the standard library.

Thanks!

---
[1] https://codereview.appspot.com/76540043/