### PR TITLE
API for granting and revoking admin privileges

### DIFF
--- a/db/user.go
+++ b/db/user.go
@@ -103,13 +103,22 @@ func (r *userRepo) Create(tx repo.Transaction, usr user.User) (err error) {
 }
 
 func (r *userRepo) Disable(tx repo.Transaction, userID string, disable bool) error {
+	return r.setUserField("disabled", tx, userID, disable)
+}
+
+func (r *userRepo) SetAdmin(tx repo.Transaction, userID string, setAdmin bool) error {
+	return r.setUserField("admin", tx, userID, setAdmin)
+}
+
+func (r *userRepo) setUserField(fieldName string, tx repo.Transaction, userID string, fieldValue interface{}) error {
 	if userID == "" {
 		return user.ErrorInvalidID
 	}
 
-	qt := pq.QuoteIdentifier(userTableName)
+	table := pq.QuoteIdentifier(userTableName)
+	field := pq.QuoteIdentifier(fieldName)
 	ex := r.executor(tx)
-	result, err := ex.Exec(fmt.Sprintf("UPDATE %s SET disabled = $2 WHERE id = $1", qt), userID, disable)
+	result, err := ex.Exec(fmt.Sprintf("UPDATE %s SET %s = $2 WHERE id = $1", table, field), userID, fieldValue)
 	if err != nil {
 		return err
 	}

--- a/functional/repo/user_repo_test.go
+++ b/functional/repo/user_repo_test.go
@@ -288,6 +288,79 @@ func TestDisableUser(t *testing.T) {
 	}
 }
 
+func TestSetAdminUser(t *testing.T) {
+
+	tests := []struct {
+		id    string
+		admin bool
+		err   error
+	}{
+		{
+			id: "WasAdmin",
+		},
+		{
+			id:    "WasAdmin",
+			admin: true,
+		},
+		{
+			id: "WasntAdmin",
+		},
+		{
+			id:    "WasntAdmin",
+			admin: true,
+		},
+		{
+			id:  "NO SUCH ID",
+			err: user.ErrorNotFound,
+		},
+		{
+			id:    "NO SUCH ID",
+			err:   user.ErrorNotFound,
+			admin: true,
+		},
+		{
+			id:  "",
+			err: user.ErrorInvalidID,
+		},
+	}
+
+	for i, tt := range tests {
+		repo := makeTestUserRepo()
+		err := repo.Create(nil, user.User{
+			ID:    "WasAdmin",
+			Email: "WasAdmin@example.com",
+			Admin: true,
+		})
+		if err != nil {
+			t.Fatalf("case %d: couldn't add user: %q", i, err)
+		}
+
+		err = repo.Create(nil, user.User{
+			ID:    "WasntAdmin",
+			Email: "WasntAdmin@example.com",
+		})
+		if err != nil {
+			t.Fatalf("case %d: couldn't add user: %q", i, err)
+		}
+
+		err = repo.SetAdmin(nil, tt.id, tt.admin)
+		switch {
+		case err != tt.err:
+			t.Errorf("case %d: want=%q, got=%q", i, tt.err, err)
+		case tt.err == nil:
+			gotUser, err := repo.Get(nil, tt.id)
+			if err != nil {
+				t.Fatalf("case %d: want nil err, got %q", i, err)
+			}
+
+			if gotUser.Admin != tt.admin {
+				t.Errorf("case %d: admin status want=%v got=%v",
+					i, tt.admin, gotUser.Admin)
+			}
+		}
+	}
+}
+
 func TestAttachRemoteIdentity(t *testing.T) {
 	tests := []struct {
 		id  string

--- a/integration/user_api_test.go
+++ b/integration/user_api_test.go
@@ -573,6 +573,48 @@ func TestDisableUser(t *testing.T) {
 	}
 }
 
+func TestSetAdminUser(t *testing.T) {
+	tests := []struct {
+		id    string
+		admin bool
+	}{
+		{
+			id:    "ID-2",
+			admin: true,
+		},
+		{
+			id:    "ID-4",
+			admin: false,
+		},
+	}
+
+	for i, tt := range tests {
+		f := makeUserAPITestFixtures()
+
+		usr, err := f.client.Users.Get(tt.id).Do()
+		if err != nil {
+			t.Fatalf("case %v: unexpected error: %v", i, err)
+		}
+		if usr.User.Admin == tt.admin {
+			t.Fatalf("case %v: misconfigured test, initial admin state should be %v but was %v", i, !tt.admin, usr.User.Admin)
+		}
+
+		_, err = f.client.Users.SetAdmin(tt.id, &schema.UserSetAdminRequest{
+			Admin: tt.admin,
+		}).Do()
+		if err != nil {
+			t.Fatalf("case %v: unexpected error: %v", i, err)
+		}
+		usr, err = f.client.Users.Get(tt.id).Do()
+		if err != nil {
+			t.Fatalf("case %v: unexpected error: %v", i, err)
+		}
+		if usr.User.Admin != tt.admin {
+			t.Errorf("case %v: user admin state incorrect. wanted: %v found: %v", i, tt.admin, usr.User.Admin)
+		}
+	}
+}
+
 type testEmailer struct {
 	cantEmail       bool
 	lastEmail       string

--- a/schema/workerschema/v1-gen.go
+++ b/schema/workerschema/v1-gen.go
@@ -137,7 +137,8 @@ type UserCreateResponseUser struct {
 }
 
 type UserDisableRequest struct {
-	// Disable: If true, disable this user, if false, enable them
+	// Disable: If true, disable this user, if false, enable them. No error
+	// is signaled if the user state doesn't change.
 	Disable bool `json:"disable,omitempty"`
 }
 
@@ -147,6 +148,17 @@ type UserDisableResponse struct {
 
 type UserResponse struct {
 	User *User `json:"user,omitempty"`
+}
+
+type UserSetAdminRequest struct {
+	// Admin: If true, grant admin status to user, if false, revoke admin
+	// status from them. No error is signaled if the user admin status
+	// doesn't change.
+	Admin bool `json:"admin,omitempty"`
+}
+
+type UserSetAdminResponse struct {
+	Ok bool `json:"ok,omitempty"`
 }
 
 type UsersResponse struct {
@@ -602,6 +614,89 @@ func (c *UsersListCall) Do() (*UsersResponse, error) {
 	//   "path": "users",
 	//   "response": {
 	//     "$ref": "UsersResponse"
+	//   }
+	// }
+
+}
+
+// method id "dex.User.SetAdmin":
+
+type UsersSetAdminCall struct {
+	s                   *Service
+	id                  string
+	usersetadminrequest *UserSetAdminRequest
+	opt_                map[string]interface{}
+}
+
+// SetAdmin: Grant or revoke administrator status.
+func (r *UsersService) SetAdmin(id string, usersetadminrequest *UserSetAdminRequest) *UsersSetAdminCall {
+	c := &UsersSetAdminCall{s: r.s, opt_: make(map[string]interface{})}
+	c.id = id
+	c.usersetadminrequest = usersetadminrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *UsersSetAdminCall) Fields(s ...googleapi.Field) *UsersSetAdminCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *UsersSetAdminCall) Do() (*UserSetAdminResponse, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.usersetadminrequest)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "users/{id}/admin")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"id": c.id,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", "google-api-go-client/0.5")
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *UserSetAdminResponse
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Grant or revoke administrator status.",
+	//   "httpMethod": "POST",
+	//   "id": "dex.User.SetAdmin",
+	//   "parameterOrder": [
+	//     "id"
+	//   ],
+	//   "parameters": {
+	//     "id": {
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "users/{id}/admin",
+	//   "request": {
+	//     "$ref": "UserSetAdminRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "UserSetAdminResponse"
 	//   }
 	// }
 

--- a/schema/workerschema/v1-json.go
+++ b/schema/workerschema/v1-json.go
@@ -176,12 +176,31 @@ const DiscoveryJSON = `{
       "properties": {
         "disable": {
           "type": "boolean",
-          "description": "If true, disable this user, if false, enable them"
+          "description": "If true, disable this user, if false, enable them. No error is signaled if the user state doesn't change."
         }
       }
     },
     "UserDisableResponse": {
       "id": "UserDisableResponse",
+      "type": "object",
+      "properties": {
+        "ok": {
+          "type": "boolean"
+        }
+      }
+    },
+    "UserSetAdminRequest": {
+      "id": "UserSetAdminRequest",
+      "type": "object",
+      "properties": {
+        "admin": {
+          "type": "boolean",
+          "description": "If true, grant admin status to user, if false, revoke admin status from them. No error is signaled if the user admin status doesn't change."
+        }
+      }
+    },
+    "UserSetAdminResponse": {
+      "id": "UserSetAdminResponse",
       "type": "object",
       "properties": {
         "ok": {
@@ -294,6 +313,28 @@ const DiscoveryJSON = `{
           },
           "response": {
             "$ref": "UserDisableResponse"
+          }
+        },
+        "SetAdmin": {
+          "id": "dex.User.SetAdmin",
+          "description": "Grant or revoke administrator status.",
+          "httpMethod": "POST",
+          "path": "users/{id}/admin",
+          "parameters": {
+            "id": {
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "id"
+          ],
+          "request": {
+            "$ref": "UserSetAdminRequest"
+          },
+          "response": {
+            "$ref": "UserSetAdminResponse"
           }
         }
       }

--- a/schema/workerschema/v1.json
+++ b/schema/workerschema/v1.json
@@ -182,6 +182,25 @@
           "type": "boolean"
         }
       }
+    },
+    "UserSetAdminRequest": {
+      "id": "UserSetAdminRequest",
+      "type": "object",
+      "properties": {
+        "admin": {
+          "type": "boolean",
+          "description": "If true, grant admin status to user, if false, revoke admin status from them. No error is signaled if the user admin status doesn't change."
+        }
+      }
+    },
+    "UserSetAdminResponse": {
+      "id": "UserSetAdminResponse",
+      "type": "object",
+      "properties": {
+        "ok": {
+          "type": "boolean"
+        }
+      }
     }
   },
   "resources": {
@@ -288,6 +307,28 @@
           },
           "response": {
             "$ref": "UserDisableResponse"
+          }
+        },
+        "SetAdmin": {
+          "id": "dex.User.SetAdmin",
+          "description": "Grant or revoke administrator status.",
+          "httpMethod": "POST",
+          "path": "users/{id}/admin",
+          "parameters": {
+            "id": {
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "id"
+          ],
+          "request": {
+            "$ref": "UserSetAdminRequest"
+          },
+          "response": {
+            "$ref": "UserSetAdminResponse"
           }
         }
       }

--- a/user/api/api.go
+++ b/user/api/api.go
@@ -136,6 +136,21 @@ func (u *UsersAPI) DisableUser(creds Creds, userID string, disable bool) (schema
 	}, nil
 }
 
+func (u *UsersAPI) SetAdmin(creds Creds, userID string, setAdmin bool) (schema.UserSetAdminResponse, error) {
+	log.Infof("userAPI: SetAdmin")
+	if !u.Authorize(creds) {
+		return schema.UserSetAdminResponse{}, ErrorUnauthorized
+	}
+
+	if err := u.manager.SetAdmin(userID, setAdmin); err != nil {
+		return schema.UserSetAdminResponse{}, mapError(err)
+	}
+
+	return schema.UserSetAdminResponse{
+		Ok: true,
+	}, nil
+}
+
 func (u *UsersAPI) CreateUser(creds Creds, usr schema.User, redirURL url.URL) (schema.UserCreateResponse, error) {
 	log.Infof("userAPI: CreateUser")
 	if !u.Authorize(creds) {

--- a/user/manager.go
+++ b/user/manager.go
@@ -118,6 +118,22 @@ func (m *Manager) Disable(userID string, disabled bool) error {
 	return nil
 }
 
+func (m *Manager) SetAdmin(userID string, setAdmin bool) error {
+	tx, err := m.begin()
+
+	if err = m.userRepo.SetAdmin(tx, userID, setAdmin); err != nil {
+		rollback(tx)
+		return err
+	}
+
+	if err = tx.Commit(); err != nil {
+		rollback(tx)
+		return err
+	}
+
+	return nil
+}
+
 // RegisterWithRemoteIdentity creates new user and attaches the given remote identity.
 func (m *Manager) RegisterWithRemoteIdentity(email string, emailVerified bool, rid RemoteIdentity) (string, error) {
 	tx, err := m.begin()

--- a/user/user.go
+++ b/user/user.go
@@ -82,6 +82,8 @@ type UserRepo interface {
 
 	Disable(tx repo.Transaction, id string, disabled bool) error
 
+	SetAdmin(tx repo.Transaction, id string, admin bool) error
+
 	Update(repo.Transaction, User) error
 
 	GetByRemoteIdentity(repo.Transaction, RemoteIdentity) (User, error)
@@ -265,6 +267,19 @@ func (r *memUserRepo) Disable(_ repo.Transaction, id string, disable bool) error
 		return ErrorNotFound
 	}
 	user.Disabled = disable
+	r.set(user)
+	return nil
+}
+
+func (r *memUserRepo) SetAdmin(_ repo.Transaction, id string, admin bool) error {
+	if id == "" {
+		return ErrorInvalidID
+	}
+	user, ok := r.usersByID[id]
+	if !ok {
+		return ErrorNotFound
+	}
+	user.Admin = admin
 	r.set(user)
 	return nil
 }


### PR DESCRIPTION
This change exposes a new public API that provides a way for clients to grant or revoke administrative privileges on users.

This change follows the design and implementation of Disable very closely.