### PR TITLE
server: Share token code

### DIFF
--- a/build
+++ b/build
@@ -20,7 +20,7 @@ fi
 
 rm -rf $GOPATH/src/github.com/coreos/dex
 mkdir -p $GOPATH/src/github.com/coreos/
-ln -s ${PWD} $GOPATH/src/github.com/coreos/dex
+[ -d $GOPATH/src/github.com/coreos/dex ] || ln -s ${PWD} $GOPATH/src/github.com/coreos/dex
 
 LD_FLAGS="-X main.version=$(git rev-parse HEAD)"
 go build -o bin/dex-worker -ldflags="$LD_FLAGS" github.com/coreos/dex/cmd/dex-worker

--- a/build
+++ b/build
@@ -20,6 +20,8 @@ fi
 
 rm -rf $GOPATH/src/github.com/coreos/dex
 mkdir -p $GOPATH/src/github.com/coreos/
+
+# Only attempt to link dex into godeps if it isn't already there
 [ -d $GOPATH/src/github.com/coreos/dex ] || ln -s ${PWD} $GOPATH/src/github.com/coreos/dex
 
 LD_FLAGS="-X main.version=$(git rev-parse HEAD)"

--- a/test
+++ b/test
@@ -14,7 +14,7 @@ COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE="connector db integration pkg/crypto pkg/flag pkg/http pkg/net pkg/time pkg/html functional/repo server session user/api"
+TESTABLE="connector db integration pkg/crypto pkg/flag pkg/http pkg/net pkg/time pkg/html functional/repo server session user user/api"
 FORMATTABLE="$TESTABLE cmd/dexctl cmd/dex-worker cmd/dex-overlord examples/app functional pkg/log"
 
 # user has not provided PKG override

--- a/user/email_verification.go
+++ b/user/email_verification.go
@@ -1,7 +1,6 @@
 package user
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -13,15 +12,6 @@ import (
 	"github.com/coreos/go-oidc/oidc"
 )
 
-const (
-	// Claim representing where a user should be sent after verifying their email address.
-	ClaimEmailVerificationCallback = "http://coreos.com/email/verification-callback"
-
-	// ClaimEmailVerificationEmail represents the email to be verified. Note
-	// that we are intentionally not using the "email" claim for this purpose.
-	ClaimEmailVerificationEmail = "http://coreos.com/email/verificationEmail"
-)
-
 var (
 	clock = clockwork.NewRealClock()
 )
@@ -29,7 +19,6 @@ var (
 // NewEmailVerification creates an object which can be sent to a user in serialized form to verify that they control an email address.
 // The clientID is the ID of the registering user. The callback is where a user should land after verifying their email.
 func NewEmailVerification(user User, clientID string, issuer url.URL, callback url.URL, expires time.Duration) EmailVerification {
-
 	claims := oidc.NewClaims(issuer.String(), user.ID, clientID, clock.Now(), clock.Now().Add(expires))
 	claims.Add(ClaimEmailVerificationCallback, callback.String())
 	claims.Add(ClaimEmailVerificationEmail, user.Email)
@@ -37,90 +26,46 @@ func NewEmailVerification(user User, clientID string, issuer url.URL, callback u
 }
 
 type EmailVerification struct {
-	claims jose.Claims
+	Claims jose.Claims
 }
 
-// Token serializes the EmailVerification into a signed JWT.
-func (e EmailVerification) Token(signer jose.Signer) (string, error) {
-	if signer == nil {
-		return "", errors.New("no signer")
-	}
-
-	jwt, err := jose.NewSignedJWT(e.claims, signer)
-	if err != nil {
-		return "", err
-	}
-
-	return jwt.Encode(), nil
-}
-
-// ParseAndVerifyEmailVerificationToken parses a string into a an EmailVerification, verifies the signature, and ensures that required claims are present.
-// In addition to the usual claims required by the OIDC spec, "aud" and "sub" must be present as well as ClaimEmailVerificationCallback and ClaimEmailVerificationEmail.
-func ParseAndVerifyEmailVerificationToken(token string, issuer url.URL, keys []key.PublicKey) (EmailVerification, error) {
-	jwt, err := jose.ParseJWT(token)
+// Assumes that parseAndVerifyTokenClaims has already been called on claims
+func verifyEmailVerificationClaims(claims jose.Claims) (EmailVerification, error) {
+	email, ok, err := claims.StringClaim(ClaimEmailVerificationEmail)
 	if err != nil {
 		return EmailVerification{}, err
 	}
-
-	claims, err := jwt.Claims()
-	if err != nil {
-		return EmailVerification{}, err
-	}
-
-	clientID, ok, err := claims.StringClaim("aud")
-	if err != nil {
-		return EmailVerification{}, err
-	}
-	if !ok {
-		return EmailVerification{}, errors.New("no aud(client ID) claim")
+	if !ok || email == "" {
+		return EmailVerification{}, fmt.Errorf("no %q claim", ClaimEmailVerificationEmail)
 	}
 
 	cb, ok, err := claims.StringClaim(ClaimEmailVerificationCallback)
 	if err != nil {
 		return EmailVerification{}, err
 	}
-	if cb == "" {
+	if !ok || cb == "" {
 		return EmailVerification{}, fmt.Errorf("no %q claim", ClaimEmailVerificationCallback)
 	}
 	if _, err := url.Parse(cb); err != nil {
 		return EmailVerification{}, fmt.Errorf("callback URL not parseable: %v", cb)
 	}
 
-	email, ok, err := claims.StringClaim(ClaimEmailVerificationEmail)
+	return EmailVerification{claims}, nil
+}
+
+// ParseAndVerifyEmailVerificationToken parses a string into a an EmailVerification, verifies the signature, and ensures that required claims are present.
+// In addition to the usual claims required by the OIDC spec, "aud" and "sub" must be present as well as ClaimEmailVerificationCallback and ClaimEmailVerificationEmail.
+func ParseAndVerifyEmailVerificationToken(token string, issuer url.URL, keys []key.PublicKey) (EmailVerification, error) {
+	tokenClaims, err := parseAndVerifyTokenClaims(token, issuer, keys)
 	if err != nil {
 		return EmailVerification{}, err
 	}
-	if email == "" {
-		return EmailVerification{}, fmt.Errorf("no %q claim", ClaimEmailVerificationEmail)
-	}
 
-	sub, ok, err := claims.StringClaim("sub")
-	if err != nil {
-		return EmailVerification{}, err
-	}
-	if sub == "" {
-		return EmailVerification{}, errors.New("no sub claim")
-	}
-
-	noop := func() error { return nil }
-
-	keysFunc := func() []key.PublicKey {
-		return keys
-	}
-
-	verifier := oidc.NewJWTVerifier(issuer.String(), clientID, noop, keysFunc)
-	if err := verifier.Verify(jwt); err != nil {
-		return EmailVerification{}, err
-	}
-
-	return EmailVerification{
-		claims: claims,
-	}, nil
-
+	return verifyEmailVerificationClaims(tokenClaims.Claims)
 }
 
 func (e EmailVerification) UserID() string {
-	uid, ok, err := e.claims.StringClaim("sub")
+	uid, ok, err := e.Claims.StringClaim("sub")
 	if !ok || err != nil {
 		panic("EmailVerification: no sub claim. This should be impossible.")
 	}
@@ -128,7 +73,7 @@ func (e EmailVerification) UserID() string {
 }
 
 func (e EmailVerification) Email() string {
-	email, ok, err := e.claims.StringClaim(ClaimEmailVerificationEmail)
+	email, ok, err := e.Claims.StringClaim(ClaimEmailVerificationEmail)
 	if !ok || err != nil {
 		panic("EmailVerification: no email claim. This should be impossible.")
 	}
@@ -136,7 +81,7 @@ func (e EmailVerification) Email() string {
 }
 
 func (e EmailVerification) Callback() *url.URL {
-	cb, ok, err := e.claims.StringClaim(ClaimEmailVerificationCallback)
+	cb, ok, err := e.Claims.StringClaim(ClaimEmailVerificationCallback)
 	if !ok || err != nil {
 		panic("EmailVerification: no callback claim. This should be impossible.")
 	}

--- a/user/email_verification_test.go
+++ b/user/email_verification_test.go
@@ -59,7 +59,7 @@ func TestNewEmailVerification(t *testing.T) {
 		}
 		ev := NewEmailVerification(tt.user, tt.clientID, tt.issuer, *cbURL, tt.expires)
 
-		if diff := pretty.Compare(tt.want, ev.claims); diff != "" {
+		if diff := pretty.Compare(tt.want, ev.Claims); diff != "" {
 			t.Errorf("case %d: Compare(want, got): %v", i, diff)
 		}
 
@@ -127,10 +127,11 @@ func TestEmailVerificationParseAndVerify(t *testing.T) {
 
 	for i, tt := range tests {
 
-		token, err := tt.ev.Token(tt.signer)
+		jwt, err := jose.NewSignedJWT(tt.ev.Claims, tt.signer)
 		if err != nil {
-			t.Errorf("case %d: non-nil error creating token: %v", i, err)
+			t.Fatalf("Failed to generate JWT, error=%v", err)
 		}
+		token := jwt.Encode()
 
 		ev, err := ParseAndVerifyEmailVerificationToken(token, *issuer,
 			[]key.PublicKey{*key.NewPublicKey(privKey.JWK())})
@@ -148,7 +149,7 @@ func TestEmailVerificationParseAndVerify(t *testing.T) {
 
 		}
 
-		if diff := pretty.Compare(tt.ev.claims, ev.claims); diff != "" {
+		if diff := pretty.Compare(tt.ev.Claims, ev.Claims); diff != "" {
 			t.Errorf("case %d: Compare(want, got): %v", i, diff)
 		}
 	}

--- a/user/password_test.go
+++ b/user/password_test.go
@@ -221,8 +221,6 @@ func TestPasswordResetParseAndVerify(t *testing.T) {
 
 	for i, tt := range tests {
 
-		t.Logf("TODO claims are %v", tt.ev.Claims)
-
 		jwt, err := jose.NewSignedJWT(tt.ev.Claims, tt.signer)
 		if err != nil {
 			t.Fatalf("Failed to generate JWT, error=%v", err)

--- a/user/user.go
+++ b/user/user.go
@@ -448,6 +448,11 @@ type TokenClaims struct {
 	Claims jose.Claims
 }
 
+// Returns TokenClaims if and only if
+// - the given token string is an appropriately formatted JWT
+// - the JWT contains nonempty "aud" and "sub" claims
+// - the JWT can be verified for the client associated with the "aud" claim
+//   using the given keys
 func parseAndVerifyTokenClaims(token string, issuer url.URL, keys []key.PublicKey) (TokenClaims, error) {
 	jwt, err := jose.ParseJWT(token)
 	if err != nil {


### PR DESCRIPTION
This change proposes to unify behavior and source code for token generation between email verification and password reset, in order to make it simpler to add other user-facing, token dependent services to dex.