### PR TITLE
registration: trim spaces and sanity check user email from form

### DIFF
--- a/server/register.go
+++ b/server/register.go
@@ -104,7 +104,7 @@ func handleRegisterFunc(s *Server) http.HandlerFunc {
 		trustedEmail := ses.Identity.Email != "" && idpc.TrustedEmailProvider()
 		validate := r.Form.Get("validate") == "1"
 		formErrors := []formError{}
-		email := r.Form.Get("email")
+		email := strings.TrimSpace(r.Form.Get("email"))
 
 		// only auto-populate the first time the page is GETted, not on
 		// subsequent POSTs
@@ -114,7 +114,7 @@ func handleRegisterFunc(s *Server) http.HandlerFunc {
 
 		password := r.Form.Get("password")
 		if validate {
-			if email == "" {
+			if email == "" || !user.ValidEmail(email) {
 				formErrors = append(formErrors, formError{"email", "Please supply a valid email"})
 			}
 			if local && password == "" {

--- a/server/register_test.go
+++ b/server/register_test.go
@@ -147,6 +147,37 @@ func TestHandleRegister(t *testing.T) {
 			wantUserCreated: true,
 		},
 		{
+			// User comes in with spaces in their email, having submitted the
+			// form. The email is trimmed and the user is created.
+			query: url.Values{
+				"code":     []string{"code-2"},
+				"validate": []string{"1"},
+				"email":    str("\t\ntest@example.com "),
+				"password": str("password"),
+			},
+			connID:          "local",
+			wantStatus:      http.StatusSeeOther,
+			wantUserCreated: true,
+		},
+		{
+			// User comes in with an invalid email, having submitted the form.
+			// The email is rejected and the user is not created.
+			query: url.Values{
+				"code":     []string{"code-2"},
+				"validate": []string{"1"},
+				"email":    str("aninvalidemail"),
+				"password": str("password"),
+			},
+			connID:     "local",
+			wantStatus: http.StatusBadRequest,
+			wantFormValues: url.Values{
+				"code":     str("code-3"),
+				"email":    str("aninvalidemail"),
+				"password": str("password"),
+				"validate": str("1"),
+			},
+		},
+		{
 			// User comes in with a valid code, having submitted the form, but
 			// there's no password.
 			query: url.Values{


### PR DESCRIPTION
Trim spaces when registering emails to address #163.

Also added a basic sanity check to catch invalid emails. Before you could enter an email like "asfddsaf asdf asdf".