### PR TITLE
user: fix bug in ValidEmail helper

### DIFF
--- a/user/user.go
+++ b/user/user.go
@@ -163,10 +163,9 @@ func ValidEmail(email string) bool {
 		return false
 	}
 
-	if address.Name != "" || address.Address == "" {
-		return false
-	}
-	return true
+	// Has mail.ParseAddress parsed the entire string and only found a single
+	// address without a name?
+	return address.Address == email
 }
 
 func ValidPassword(plaintext string) bool {

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -103,6 +103,9 @@ func TestValidEmail(t *testing.T) {
 		{"r@r.com", true},
 		{"Barry Gibbs <bg@example.com>", false},
 		{"", false},
+		{"invalidemail", false},
+		{"example@example.com example@example.com", false},
+		{"example@example.com Hello, 世界", false},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
mail.ParseAddress will stop parsing a string once it finds a valid
email address. This means you could give ValidUser an email
address followed by junk and it would mark it valid.

This commit fixes this behavior and adds some more test cases.

Fixes #189