### PR TITLE
*: trim newlines from base64 command for Linux compatibility

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -41,7 +41,7 @@ The build script will build all dex components.
 
 dex needs a 32 byte base64-encoded key which will be used to encrypt the private keys in the database. A good way to generate the key is to read from /dev/random:
 
-`DEX_KEY_SECRET=$(dd if=/dev/random bs=1 count=32 2>/dev/null | base64)`
+`DEX_KEY_SECRET=$(dd if=/dev/random bs=1 count=32 2>/dev/null | base64 | tr -d '\n')`
 
 The dex overlord and workers allow multiple key secrets (separated by commas) to be passed but only the first will be used to encrypt data; the rest are there for decryption only; this scheme allows for the rotation of keys without downtime (assuming a rolling restart of workers).
 
@@ -49,7 +49,7 @@ The dex overlord and workers allow multiple key secrets (separated by commas) to
 
 The dex overlord has a an API which is very powerful - you can create Admin users with it, so it needs to be protected somehow. This is accomplished by requiring that a secret is passed via the Authorization header of each request. This secret is 128 bytes base64 encoded, and should be sufficiently random so as to make guessing impractical:
 
-`DEX_OVERLORD_ADMIN_API_SECRET=$(dd if=/dev/random bs=1 count=128 2>/dev/null | base64)`
+`DEX_OVERLORD_ADMIN_API_SECRET=$(dd if=/dev/random bs=1 count=128 2>/dev/null | base64 | tr -d '\n')`
 
 # Start the overlord
 

--- a/contrib/standup-db.sh
+++ b/contrib/standup-db.sh
@@ -25,13 +25,13 @@ export DEX_WORKER_DB_URL=$DEX_DB_URL
 dropdb $DEX_DB; createdb $DEX_DB
 
 
-DEX_KEY_SECRET=$(dd if=/dev/random bs=1 count=32 2>/dev/null | base64)
+DEX_KEY_SECRET=$(dd if=/dev/random bs=1 count=32 2>/dev/null | base64 | tr -d '\n')
 
 # Start the overlord
 export DEX_OVERLORD_DB_URL=$DEX_DB_URL
 export DEX_OVERLORD_KEY_SECRETS=$DEX_KEY_SECRET
 export DEX_OVERLORD_KEY_PERIOD=1h
-export DEX_OVERLORD_ADMIN_API_SECRET=$(dd if=/dev/random bs=1 count=128 2>/dev/null | base64)
+export DEX_OVERLORD_ADMIN_API_SECRET=$(dd if=/dev/random bs=1 count=128 2>/dev/null | base64 | tr -d '\n')
 ./bin/dex-overlord &
 echo "Waiting for overlord to start..."
 until $(curl --output /dev/null --silent --fail http://localhost:5557/health); do


### PR DESCRIPTION
base64 wraps lines on Linux after 76 characters. Use tr to trim
the newlines in a portable way.