### PR TITLE
*: use example.com in place of coreos.com

### DIFF
--- a/build-docker-push
+++ b/build-docker-push
@@ -9,7 +9,7 @@ if [ -v $DOCKER_USER ] || [ -v $DOCKER_PASSWORD ]; then
     echo "env variables not set: DOCKER_USER, DOCKER_PASSWORD. skipping login, assuming creds in .dockercfg"
 else
     echo logging in as $DOCKER_USER
-    docker login --username="$DOCKER_USER" --password="$DOCKER_PASSWORD" --email="docker.login@coreos.com" $DOCKER_REGISTRY
+    docker login --username="$DOCKER_USER" --password="$DOCKER_PASSWORD" --email="dex@example.com" $DOCKER_REGISTRY
 fi
 
 git_sha=$(git rev-parse HEAD)

--- a/cmd/dex-worker/main.go
+++ b/cmd/dex-worker/main.go
@@ -41,7 +41,7 @@ func main() {
 	emailTemplateDirs := flagutil.StringSliceFlag{"./static/email"}
 	fs.Var(&emailTemplateDirs, "email-templates", "comma separated list of directories of email template files")
 
-	emailFrom := fs.String("email-from", "no-reply@coreos.com", "emails sent from dex will come from this address")
+	emailFrom := fs.String("email-from", "", "emails sent from dex will come from this address")
 	emailConfig := fs.String("email-cfg", "./static/fixtures/emailer.json", "configures emailer.")
 
 	enableRegistration := fs.Bool("enable-registration", false, "Allows users to self-register")

--- a/examples/emailtester/main.go
+++ b/examples/emailtester/main.go
@@ -54,7 +54,7 @@ func main() {
 	log.EnableDebug()
 
 	emailTemplates := flag.String("templates-dir", "./static/email", "directory of email template files")
-	emailFrom := flag.String("from", "no-reply@coreos.com", "")
+	emailFrom := flag.String("from", "no-reply@example.com", "")
 	emailTo := flag.String("to", "", "")
 	emailConfig := flag.String("cfg", "./static/fixtures/emailer.json", "configures emailer.")
 	tplName := flag.String("template", "verify-email", "which email template to use.")


### PR DESCRIPTION
Align with RFC2606 for example email addresses, using example.com
in place of coreos.com where appropriate.

Fix #86, supersedes #187 