### PR TITLE
Godeps: update coreos/go-oidc to include OIDC race condition fixes

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -21,23 +21,23 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/http",
-			"Rev": "faf70c34f9c411f234eb96d23c518c087cd96d79"
+			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/jose",
-			"Rev": "faf70c34f9c411f234eb96d23c518c087cd96d79"
+			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/key",
-			"Rev": "faf70c34f9c411f234eb96d23c518c087cd96d79"
+			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/oauth2",
-			"Rev": "faf70c34f9c411f234eb96d23c518c087cd96d79"
+			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/oidc",
-			"Rev": "faf70c34f9c411f234eb96d23c518c087cd96d79"
+			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
 		},
 		{
 			"ImportPath": "github.com/coreos/pkg/capnslog",

--- a/Godeps/_workspace/src/github.com/coreos/go-oidc/oidc/provider.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-oidc/oidc/provider.go
@@ -25,6 +25,9 @@ const (
 	discoveryConfigPath = "/.well-known/openid-configuration"
 )
 
+// internally configurable for tests
+var minimumProviderConfigSyncInterval = MinimumProviderConfigSyncInterval
+
 type ProviderConfig struct {
 	Issuer                            string    `json:"issuer"`
 	AuthEndpoint                      string    `json:"authorization_endpoint"`
@@ -172,8 +175,8 @@ func nextSyncAfter(exp time.Time, clock clockwork.Clock) time.Duration {
 	t := exp.Sub(clock.Now()) / 2
 	if t > MaximumProviderConfigSyncInterval {
 		t = MaximumProviderConfigSyncInterval
-	} else if t < MinimumProviderConfigSyncInterval {
-		t = MinimumProviderConfigSyncInterval
+	} else if t < minimumProviderConfigSyncInterval {
+		t = minimumProviderConfigSyncInterval
 	}
 
 	return t


### PR DESCRIPTION
Update `github.com/coreos/go-oidc/...` to include coreos/go-oidc#27 which fixes a race condition in the OIDC connector when syncing provider configurations.