### PR TITLE
Godeps: update github.com/coreos/go-oidc/oidc to fix field name

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -21,23 +21,23 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/http",
-			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
+			"Rev": "48e2a9be3918af3299c4b390399346447eefea22"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/jose",
-			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
+			"Rev": "48e2a9be3918af3299c4b390399346447eefea22"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/key",
-			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
+			"Rev": "48e2a9be3918af3299c4b390399346447eefea22"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/oauth2",
-			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
+			"Rev": "48e2a9be3918af3299c4b390399346447eefea22"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-oidc/oidc",
-			"Rev": "024cdeee09d02fb439eb55bc422e582ac115615b"
+			"Rev": "48e2a9be3918af3299c4b390399346447eefea22"
 		},
 		{
 			"ImportPath": "github.com/coreos/pkg/capnslog",

--- a/Godeps/_workspace/src/github.com/coreos/go-oidc/oidc/provider.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-oidc/oidc/provider.go
@@ -36,7 +36,7 @@ type ProviderConfig struct {
 	ResponseTypesSupported            []string  `json:"response_types_supported"`
 	GrantTypesSupported               []string  `json:"grant_types_supported"`
 	SubjectTypesSupported             []string  `json:"subject_types_supported"`
-	IDTokenAlgValuesSupported         []string  `json:"id_token_alg_values_supported"`
+	IDTokenAlgValuesSupported         []string  `json:"id_token_signing_alg_values_supported"`
 	TokenEndpointAuthMethodsSupported []string  `json:"token_endpoint_auth_methods_supported"`
 	ExpiresAt                         time.Time `json:"-"`
 }


### PR DESCRIPTION
Correct provider config field "id_token_alg_values_supported" to "id_token_signing_alg_values_supported".

Fixes #212