### PR TITLE
cmd, db: verify at least one secret is passed to --key-secrets

### DIFF
--- a/cmd/dex-overlord/main.go
+++ b/cmd/dex-overlord/main.go
@@ -72,6 +72,10 @@ func main() {
 		log.Fatalf("Unable to use --admin-listen flag: %v", err)
 	}
 
+	if len(keySecrets.BytesSlice()) == 0 {
+		log.Fatalf("Must specify at least one key secret")
+	}
+
 	dbCfg := db.Config{
 		DSN:                *dbURL,
 		MaxIdleConnections: 1,

--- a/cmd/dex-worker/main.go
+++ b/cmd/dex-worker/main.go
@@ -135,6 +135,9 @@ func main() {
 			UsersFile:      *users,
 		}
 	} else {
+		if len(keySecrets.BytesSlice()) == 0 {
+			log.Fatalf("Must specify at least one key secret")
+		}
 		if *dbMaxIdleConns == 0 {
 			log.Warning("Running with no limit on: database idle connections")
 		}

--- a/db/key.go
+++ b/db/key.go
@@ -90,6 +90,9 @@ type privateKeySetBlob struct {
 }
 
 func NewPrivateKeySetRepo(dbm *gorp.DbMap, useOldFormat bool, secrets ...[]byte) (*PrivateKeySetRepo, error) {
+	if len(secrets) == 0 {
+		return nil, errors.New("must provide at least one key secret")
+	}
 	for i, secret := range secrets {
 		if len(secret) != 32 {
 			return nil, fmt.Errorf("key secret %d: expected 32-byte secret", i)

--- a/db/key_test.go
+++ b/db/key_test.go
@@ -7,6 +7,10 @@ import (
 func TestNewPrivateKeySetRepoInvalidKey(t *testing.T) {
 	_, err := NewPrivateKeySetRepo(nil, false, []byte("sharks"))
 	if err == nil {
-		t.Fatalf("Expected non-nil error")
+		t.Errorf("Expected non-nil error for key secret that was not 32 bytes")
+	}
+	_, err = NewPrivateKeySetRepo(nil, false)
+	if err == nil {
+		t.Fatalf("Expected non-nil error when creating repo with no key secrets")
 	}
 }


### PR DESCRIPTION
Passing an empty list to the overlord's --key-secrets flag currently causes an out of range panic. Always check to ensure there's at least one element.

Fixes #130