### PR TITLE
cmd: reduce backoff max when worker is waiting for connectors

### DIFF
--- a/cmd/dex-worker/main.go
+++ b/cmd/dex-worker/main.go
@@ -169,7 +169,7 @@ func main() {
 		if len(cfgs) > 0 && err == nil {
 			break
 		}
-		sleep = ptime.ExpBackoff(sleep, time.Minute)
+		sleep = ptime.ExpBackoff(sleep, 8*time.Second)
 		if err != nil {
 			log.Errorf("Unable to load connectors, retrying in %v: %v", sleep, err)
 		} else {


### PR DESCRIPTION
Reduces the max amount of time between retries when waiting for the database to populate connectors from 1 minute to 8 seconds. 

fixes #177