### PR TITLE
cmd: display help when --help flag is present

### DIFF
--- a/cmd/dexctl/main.go
+++ b/cmd/dexctl/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"flag"
+	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -13,7 +14,7 @@ import (
 
 var (
 	cliName        = "dexctl"
-	cliDescription = "???"
+	cliDescription = "A tool for interacting with the dex system"
 
 	commands []*command
 	globalFS = flag.NewFlagSet(cliName, flag.ExitOnError)
@@ -59,8 +60,14 @@ func main() {
 	for _, c := range commands {
 		if c.Name == args[0] {
 			cmd = c
+			// Don't print the default help message.
+			c.Flags.SetOutput(ioutil.Discard)
 			if err := c.Flags.Parse(args[1:]); err != nil {
-				stderr("%v", err)
+				if err == flag.ErrHelp {
+					printCommandUsage(c)
+				} else {
+					stderr("%v", err)
+				}
 				os.Exit(2)
 			}
 			break


### PR DESCRIPTION
Went from this:

```
$ ./bin/dexctl set-connector-configs --help
Usage:
flag: help requested
```

To this:

```
$ ./bin/dexctl set-connector-configs --help
NAME:
	set-connector-configs - Overwrite the current IdP connector configs with those from a local file.

USAGE:
	dexctl set-connector-configs <FILE>

DESCRIPTION:
	

For help on global options run "dexctl help"
```

In the future, it'd probably be good to get the dex-worker, dex-overload, and dexctl all using the same cli package.