### PR TITLE
server: better UX when remote ID already exists

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -129,11 +130,15 @@ var connectorDisplayNameMap = map[string]string{
 	"bitbucket": "Bitbucket",
 }
 
-func execTemplate(w http.ResponseWriter, tpl *template.Template, data interface{}) {
+type Template interface {
+	Execute(io.Writer, interface{}) error
+}
+
+func execTemplate(w http.ResponseWriter, tpl Template, data interface{}) {
 	execTemplateWithStatus(w, tpl, data, http.StatusOK)
 }
 
-func execTemplateWithStatus(w http.ResponseWriter, tpl *template.Template, data interface{}, status int) {
+func execTemplateWithStatus(w http.ResponseWriter, tpl Template, data interface{}, status int) {
 	w.WriteHeader(status)
 	if err := tpl.Execute(w, data); err != nil {
 		log.Errorf("Error loading page: %q", err)

--- a/server/server.go
+++ b/server/server.go
@@ -206,7 +206,7 @@ func (s *Server) HTTPHandler() http.Handler {
 	mux.Handle(httpPathHealth, makeHealthHandler(checks))
 
 	if s.EnableRegistration {
-		mux.HandleFunc(httpPathRegister, handleRegisterFunc(s))
+		mux.HandleFunc(httpPathRegister, handleRegisterFunc(s, s.RegisterTemplate))
 	}
 
 	mux.HandleFunc(httpPathEmailVerify, handleEmailVerifyFunc(s.VerifyEmailTemplate,

--- a/server/testutil.go
+++ b/server/testutil.go
@@ -146,7 +146,8 @@ func makeTestFixtures() (*testFixtures, error) {
 		return nil, err
 	}
 
-	tpl, err := getTemplates("dex", "https://coreos.com/assets/images/brand/coreos-mark-30px.png",
+	tpl, err := getTemplates("dex",
+		"https://coreos.com/assets/images/brand/coreos-mark-30px.png",
 		true, templatesLocation)
 	if err != nil {
 		return nil, err

--- a/static/html/register.html
+++ b/static/html/register.html
@@ -4,7 +4,32 @@
   <h2 class="heading">Create Your Account</h2>
 
   {{ if .Error }}
-    <div class="error-box">{{ .Message }}</div>
+  <div class="error-box">{{ .Message }}</div>
+  {{ else if .RemoteExists }}
+     {{ with .RemoteExists }}
+     <div class="instruction-block">
+       This account is already registered.
+       If you'd like to login with that account, click here:
+     </div>
+      <div>
+        <a href="{{ .Login }}" target="_self">
+          <button class="btn btn-provider">
+            <span class="btn-text">Login</span>
+          </button>
+        </a>
+      </div>
+      <div class="instruction-block">
+        If you would like to register with a different account, click here:
+      </div>
+      <div>
+        <a href="{{ .Register }}" target="_self">
+          <button class="btn btn-provider">
+            <span class="btn-text">Register</span>
+          </button>
+        </a>
+      </div>
+     {{ end }}
+
   {{ else }}
 
     <form id="registerForm" method="POST" action="/register">


### PR DESCRIPTION
Instead of cryptic message with nowhere to, give them the choice to
login with that account or register.
