### PR TITLE
pkg: improve base64 flag error message

### DIFF
--- a/pkg/flag/base64.go
+++ b/pkg/flag/base64.go
@@ -31,7 +31,7 @@ func (f *Base64) Set(s string) error {
 	}
 
 	if len(b) != f.len {
-		return fmt.Errorf("expected %d-byte secret", f.len)
+		return fmt.Errorf("expected %d-byte secret, got %d-byte secret", f.len, len(b))
 	}
 
 	f.val = b
@@ -62,11 +62,15 @@ func (f *Base64List) Set(ss string) error {
 	if ss == "" {
 		return nil
 	}
-	for i, s := range strings.Split(ss, ",") {
+	splits := strings.Split(ss, ",")
+	for i, s := range splits {
 		b64 := NewBase64(f.len)
 		err := b64.Set(s)
 		if err != nil {
-			return fmt.Errorf("error decoding string %d: %q", i, err)
+			if len(splits) == 1 {
+				return err
+			}
+			return fmt.Errorf("error decoding string %d: %v", i, err)
 		}
 		f.val = append(f.val, b64.Bytes())
 	}


### PR DESCRIPTION
```
$ ./bin/dex-overlord --key-secrets 'YWFhYWJiYmJjY2NjZGRkZGVlZWVmZmZmZ2dnZ2hoaGgK'
invalid value "YWFhYWJiYmJjY2NjZGRkZGVlZWVmZmZmZ2dnZ2hoaGgK" for flag -key-secrets: expected 32-byte secret, got 33-byte secret
...
$ ./bin/dex-overlord --key-secrets 'YWFhYWJiYmJjY2NjZGRkZGVlZWVmZmZmZ2dnZ2hoaGg=,fasdfaf'
invalid value "YWFhYWJiYmJjY2NjZGRkZGVlZWVmZmZmZ2dnZ2hoaGg=,fasdfaf" for flag -key-secrets: error decoding string 1: illegal base64 data at input byte 4
...
```