### PR TITLE
admin: add build ignore tag to tests that don't compile

### DIFF
--- a/admin/api_test.go
+++ b/admin/api_test.go
@@ -1,3 +1,6 @@
+// NOTE: These tests are begin updated so they compile (see #257). Until then ignore.
+// +build ignore
+
 package admin
 
 import (


### PR DESCRIPTION
These tests aren't included in the top level test script so have
unintentionally been ignored and currently don't compile. Until
this is fixed (see #257) add a build tag so tools ignore them.