### PR TITLE
cmd: add version to command worker and overlord, print go version

### DIFF
--- a/cmd/dex-overlord/main.go
+++ b/cmd/dex-overlord/main.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc/key"
@@ -50,6 +52,8 @@ func main() {
 	logDebug := fs.Bool("log-debug", false, "log debug-level information")
 	logTimestamps := fs.Bool("log-timestamps", false, "prefix log lines with timestamps")
 
+	printVersion := fs.Bool("version", false, "Print the version and exit")
+
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
@@ -58,6 +62,11 @@ func main() {
 	if err := pflag.SetFlagsFromEnv(fs, "DEX_OVERLORD"); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
+	}
+
+	if *printVersion {
+		fmt.Printf("dex version %s\ngo version %s\n", strings.TrimPrefix(version, "v"), strings.TrimPrefix(runtime.Version(), "go"))
+		os.Exit(0)
 	}
 
 	if *logDebug {

--- a/cmd/dex-worker/main.go
+++ b/cmd/dex-worker/main.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/coreos/pkg/flagutil"
@@ -62,6 +64,7 @@ func main() {
 
 	dbMaxIdleConns := fs.Int("db-max-idle-conns", 0, "maximum number of connections in the idle connection pool")
 	dbMaxOpenConns := fs.Int("db-max-open-conns", 0, "maximum number of open connections to the database")
+	printVersion := fs.Bool("version", false, "Print the version and exit")
 
 	// used only if --no-db is set
 	connectors := fs.String("connectors", "./static/fixtures/connectors.json", "JSON file containg set of IDPC configs")
@@ -79,6 +82,11 @@ func main() {
 	if err := pflag.SetFlagsFromEnv(fs, "DEX_WORKER"); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
+	}
+
+	if *printVersion {
+		fmt.Printf("dex version %s\ngo version %s\n", strings.TrimPrefix(version, "v"), strings.TrimPrefix(runtime.Version(), "go"))
+		os.Exit(0)
 	}
 
 	if *logDebug {

--- a/cmd/dexctl/command_version.go
+++ b/cmd/dexctl/command_version.go
@@ -1,6 +1,11 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
 
 var (
 	// set by the top level build script
@@ -11,7 +16,7 @@ var (
 		Short: "Print the dexctl version.",
 		Long:  "Print the dexctl version.",
 		Run: func(cmd *cobra.Command, args []string) {
-			stdout(version)
+			stdout("dex version %s\ngo version %s", strings.TrimPrefix(version, "v"), strings.TrimPrefix(runtime.Version(), "go"))
 		},
 	}
 )


### PR DESCRIPTION
Output now looks like

```
$ ./bin/dexctl version
dex version 0.2.3
go version 1.5.3
$ ./bin/dex-worker --version
dex version 0.2.3
go version 1.5.3
$ ./bin/dex-overlord --version
dex version 0.2.3
go version 1.5.3
```

Attempts to mimic rkt's output:

```
$ rkt version
rkt version 0.15.0
appc version 0.7.4
```