### PR TITLE
travis: Change from after_success script to travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,30 @@ services:
 language: go
 
 go:
- - 1.4.3
- - 1.5.3
+  - 1.4.3
+  - 1.5.3
 
 env:
   - DEX_TEST_DSN="postgres://postgres@127.0.0.1:15432/postgres?sslmode=disable" ISOLATED=true
 
 install:
- - go get golang.org/x/tools/cmd/cover
- - go get golang.org/x/tools/cmd/vet
- - docker pull quay.io/coreos/postgres
+  - go get golang.org/x/tools/cmd/cover
+  - go get golang.org/x/tools/cmd/vet
+  - docker pull quay.io/coreos/postgres
 
 script:
- - docker run -d -p 127.0.0.1:15432:5432 quay.io/coreos/postgres
- - ./test
- - ./test-functional
+  - docker run -d -p 127.0.0.1:15432:5432 quay.io/coreos/postgres
+  - ./test
+  - ./test-functional
 
-after_success:
-  - if [[ "$TRAVIS_GO_VERSION" == "1.5.3" && "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master"  ]]; then ./build-docker-push ;fi
+deploy:
+  provider: script
+  script: build-docker-push
+  skip_cleanup: true
+  on:
+    branch: master
+    go: '1.5.3'
+    condition: "$TRAVIS_PULL_REQUEST = false"
 
 notifications:
   email: false


### PR DESCRIPTION
Travis has a nicer `deploy` construct which has builtin support for conditioning on branches, language versions, tags, conditions, etc. I think this should work the same for you.

* https://docs.travis-ci.com/user/deployment/script
* https://docs.travis-ci.com/user/deployment/#Conditional-Releases-with-on%3A

Fixed spacing to consistently use 2 spaces instead of a blend of 1 and 2.