### PR TITLE
*: move user API auth to middleware and fix return status

### DIFF
--- a/user/api/api.go
+++ b/user/api/api.go
@@ -31,7 +31,8 @@ var (
 	ErrorDuplicateEmail   = newError("duplicate_email", "Email already in use.", http.StatusBadRequest)
 	ErrorResourceNotFound = newError("resource_not_found", "Resource could not be found.", http.StatusNotFound)
 
-	ErrorUnauthorized = newError("unauthorized", "The given user and client are not authorized to make this request.", http.StatusUnauthorized)
+	ErrorUnauthorized = newError("unauthorized", "Necessary credentials not provided.", http.StatusUnauthorized)
+	ErrorForbidden    = newError("forbidden", "The given user and client are not authorized to make this request.", http.StatusForbidden)
 
 	ErrorMaxResultsTooHigh = newError("max_results_too_high", fmt.Sprintf("The max number of results per page is %d", maxUsersPerPage), http.StatusBadRequest)
 


### PR DESCRIPTION
Move client authentication into its own middleware and provide
differentiation between HTTP requests that do not provide
credentials (401) and requests that authenticate as a non-admin
user (403).

Closes #152