### PR TITLE
Change status code used for redirects from StatusTemporaryRedirect (3…

### DIFF
--- a/connector/connector_local.go
+++ b/connector/connector_local.go
@@ -170,7 +170,7 @@ func handleLoginFunc(lf oidc.LoginFunc, tpl *template.Template, idp *LocalIdenti
 		}
 
 		w.Header().Set("Location", redirectURL)
-		w.WriteHeader(http.StatusTemporaryRedirect)
+		w.WriteHeader(http.StatusFound)
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/connector/connector_oauth2.go
+++ b/connector/connector_oauth2.go
@@ -101,7 +101,7 @@ func (c *OAuth2Connector) handleCallbackFunc(lf oidc.LoginFunc, errorURL url.URL
 			return
 		}
 		w.Header().Set("Location", redirectURL)
-		w.WriteHeader(http.StatusTemporaryRedirect)
+		w.WriteHeader(http.StatusFound)
 		return
 	}
 }

--- a/connector/connector_oidc.go
+++ b/connector/connector_oidc.go
@@ -171,7 +171,7 @@ func (c *OIDCConnector) handleCallbackFunc(lf oidc.LoginFunc, errorURL url.URL) 
 		}
 
 		w.Header().Set("Location", redirectURL)
-		w.WriteHeader(http.StatusTemporaryRedirect)
+		w.WriteHeader(http.StatusFound)
 		return
 	}
 }

--- a/server/error.go
+++ b/server/error.go
@@ -81,5 +81,5 @@ func redirectAuthError(w http.ResponseWriter, err error, state string, redirectU
 	redirectURL.RawQuery = q.Encode()
 
 	w.Header().Set("Location", redirectURL.String())
-	w.WriteHeader(http.StatusTemporaryRedirect)
+	w.WriteHeader(http.StatusFound)
 }

--- a/server/error_test.go
+++ b/server/error_test.go
@@ -211,7 +211,7 @@ func TestWriteAuthError(t *testing.T) {
 }
 
 func TestRedirectAuthError(t *testing.T) {
-	wantCode := http.StatusTemporaryRedirect
+	wantCode := http.StatusFound
 
 	tests := []struct {
 		err         error

--- a/server/http.go
+++ b/server/http.go
@@ -383,7 +383,7 @@ func handleAuthFunc(srv OIDCServer, idpcs []connector.Connector, tpl *template.T
 				q.Set("code", key)
 				ru := httpPathRegister + "?" + q.Encode()
 				w.Header().Set("Location", ru)
-				w.WriteHeader(http.StatusTemporaryRedirect)
+				w.WriteHeader(http.StatusFound)
 				return
 			}
 		}
@@ -404,7 +404,7 @@ func handleAuthFunc(srv OIDCServer, idpcs []connector.Connector, tpl *template.T
 
 		http.SetCookie(w, createLastSeenCookie())
 		w.Header().Set("Location", lu)
-		w.WriteHeader(http.StatusTemporaryRedirect)
+		w.WriteHeader(http.StatusFound)
 		return
 	}
 }

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -104,7 +104,7 @@ func TestHandleAuthFuncResponsesSingleRedirectURL(t *testing.T) {
 				"connector_id":  []string{"fake"},
 				"scope":         []string{"openid"},
 			},
-			wantCode:     http.StatusTemporaryRedirect,
+			wantCode:     http.StatusFound,
 			wantLocation: "http://fake.example.com",
 		},
 
@@ -117,7 +117,7 @@ func TestHandleAuthFuncResponsesSingleRedirectURL(t *testing.T) {
 				"connector_id":  []string{"fake"},
 				"scope":         []string{"openid"},
 			},
-			wantCode:     http.StatusTemporaryRedirect,
+			wantCode:     http.StatusFound,
 			wantLocation: "http://fake.example.com",
 		},
 
@@ -153,7 +153,7 @@ func TestHandleAuthFuncResponsesSingleRedirectURL(t *testing.T) {
 				"connector_id":  []string{"fake"},
 				"scope":         []string{"openid"},
 			},
-			wantCode:     http.StatusTemporaryRedirect,
+			wantCode:     http.StatusFound,
 			wantLocation: "http://client.example.com/callback?error=unsupported_response_type&state=",
 		},
 
@@ -229,7 +229,7 @@ func TestHandleAuthFuncResponsesMultipleRedirectURLs(t *testing.T) {
 				"connector_id":  []string{"fake"},
 				"scope":         []string{"openid"},
 			},
-			wantCode:     http.StatusTemporaryRedirect,
+			wantCode:     http.StatusFound,
 			wantLocation: "http://fake.example.com",
 		},
 
@@ -242,7 +242,7 @@ func TestHandleAuthFuncResponsesMultipleRedirectURLs(t *testing.T) {
 				"connector_id":  []string{"fake"},
 				"scope":         []string{"openid"},
 			},
-			wantCode:     http.StatusTemporaryRedirect,
+			wantCode:     http.StatusFound,
 			wantLocation: "http://fake.example.com",
 		},
 


### PR DESCRIPTION
…07) to StatusFound (302)

HTTP code 307 aka. StatusTemporaryRedirect is used throughout the
project. However, the endpoints redirected to explicitly expects
the client to make a GET request.

If a HTTP client issues a POST request to a server and receives a
HTTP 307 redirect, it forwards the POST request to the new URL.

When using 302 the HTTP client will issue a GET request.

Fixes #287 
Needed by #178