### PR TITLE
server: don't load local connector password infos for database setups

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -136,6 +136,7 @@ func (s *Server) absURL(paths ...string) url.URL {
 	return url
 }
 
+// AddConnector configures callbacks and database access to be used by a connector.
 func (s *Server) AddConnector(cfg connector.ConnectorConfig) error {
 	connectorID := cfg.ConnectorID()
 	ns := s.IssuerURL
@@ -170,19 +171,6 @@ func (s *Server) AddConnector(cfg connector.ConnectorConfig) error {
 			UserRepo:         s.UserRepo,
 			PasswordInfoRepo: s.PasswordInfoRepo,
 		})
-
-		localCfg, ok := cfg.(*connector.LocalConnectorConfig)
-		if !ok {
-			return errors.New("config for LocalConnector not a LocalConnectorConfig?")
-		}
-
-		if len(localCfg.PasswordInfos) > 0 {
-			err := user.LoadPasswordInfos(s.PasswordInfoRepo,
-				localCfg.PasswordInfos)
-			if err != nil {
-				return err
-			}
-		}
 	}
 
 	log.Infof("Loaded IdP connector: id=%s type=%s", connectorID, cfg.ConnectorType())


### PR DESCRIPTION
Setting a local connector with password info fields using dexctl stores the entire connector JSON in the database.

```
[
    {
        "type": "local",
        "id": "local",
        "passwordInfos": [
            {
                "userId":"elroy-id",
                "passwordPlaintext": "bones"
            }
        ]
    }
]
```

When setting connectors for individual instances of a dex-worker, do not attempt to set and configure password infos read from the database.

Closes #286