### PR TITLE
 admin: tests do not compile (Fixes #257)

### DIFF
--- a/test
+++ b/test
@@ -14,7 +14,7 @@ COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE="connector db integration pkg/crypto pkg/flag pkg/http pkg/net pkg/time pkg/html functional/repo server session user user/api user/manager email"
+TESTABLE="connector db integration pkg/crypto pkg/flag pkg/http pkg/net pkg/time pkg/html functional/repo server session user user/api user/manager email admin"
 FORMATTABLE="$TESTABLE cmd/dexctl cmd/dex-worker cmd/dex-overlord examples/app functional pkg/log"
 
 # user has not provided PKG override


### PR DESCRIPTION
Fixed code for admin/api_test.go. We have changed the code comparison to error comparison  to use the same coding style as in user/api_test.go
regards