### PR TITLE
Get DN from entry, not entryDN attribute

### DIFF
--- a/connector/connector_ldap.go
+++ b/connector/connector_ldap.go
@@ -288,7 +288,6 @@ func (m *LDAPIdentityProvider) Identity(username, password string) (*oidc.Identi
 		filter := m.ParseString(m.searchFilter, username)
 
 		attributes := []string{
-			"entryDN",
 			m.nameAttribute,
 			m.emailAttribute,
 		}
@@ -304,7 +303,7 @@ func (m *LDAPIdentityProvider) Identity(username, password string) (*oidc.Identi
 			return nil, err
 		}
 
-		bindDN = sr.Entries[0].GetAttributeValue("entryDN")
+		bindDN = sr.Entries[0].DN
 		ldapName = sr.Entries[0].GetAttributeValue(m.nameAttribute)
 		ldapEmail = sr.Entries[0].GetAttributeValue(m.emailAttribute)
 


### PR DESCRIPTION
Not all LDAP servers have entryDN available as an attribute. Reading up on
https://tools.ietf.org/html/rfc5020 tells me that entryDN is intended for
making the DN available for attribute value assertions. Thus it is not
mandatory for a LDAP server to make it available as an retrievable
attribute.

The DN is always a part of the entry returned in a search result, just use
it.

Fixes #314