### PR TITLE
connector_ldap: Implement connection pooling for LDAP connections

### DIFF
--- a/Documentation/connectors-configuration.md
+++ b/Documentation/connectors-configuration.md
@@ -167,6 +167,8 @@ In addition to `id` and `type`, the `ldap` connector takes the following additio
 
 * skipCertVerification: a `boolean`. Skip server certificate chain verification.
 
+* maxIdleConn: a `integer`. Maximum number of idle LDAP Connections to keep in connection pool. Default: `5`
+
 * baseDN: a `string`. Base DN from which Bind DN is built and searches are based.
 
 * nameAttribute: a `string`. Attribute to map to Name. Default: `cn`

--- a/glide.lock
+++ b/glide.lock
@@ -65,6 +65,7 @@ imports:
   version: dfe268fd2bb5c793f4c083803609fce9806c6f80
   subpackages:
   - html
+  - context
   - html/atom
 - name: google.golang.org/api
   version: d3edb0282bde692467788c50070a9211afe75cf3

--- a/glide.yaml
+++ b/glide.yaml
@@ -60,6 +60,7 @@ import:
   version: dfe268fd2bb5c793f4c083803609fce9806c6f80
   subpackages:
   - html
+  - context
 - package: google.golang.org/api
   version: d3edb0282bde692467788c50070a9211afe75cf3
   subpackages:


### PR DESCRIPTION
The initial implementation of the LDAP connector initiates and tears down a connection for each session. Although the creation and tear-down of connections are light weight operations for most LDAP server implementations, it is not hard to imagine that this at some point will become a bottle neck and scaling issue.

This PR addresses this issue by implementing connection pooling for the LDAP connections. The pooled connections are checked for liveliness and kept alive. The number of connections to keep as well as the interval for liveliness checks are configurable.

Fixes #309