### PR TITLE
user: fix password info JSON encoding to survive round trips

### DIFF
--- a/connector/config_repo_test.go
+++ b/connector/config_repo_test.go
@@ -61,7 +61,7 @@ func TestNewConnectorConfigFromMap(t *testing.T) {
 				"type": "local",
 				"id":   "foo",
 				"passwordInfos": []map[string]string{
-					{"userId": "abc", "passwordHash": "PING"},
+					{"userId": "abc", "passwordHash": "UElORw=="}, // []byte is base64 encoded when using json.Marshasl
 					{"userId": "271", "passwordPlaintext": "pong"},
 				},
 			},

--- a/user/password.go
+++ b/user/password.go
@@ -53,9 +53,9 @@ func NewPasswordFromPlaintext(plaintext string) (Password, error) {
 type PasswordInfo struct {
 	UserID string
 
-	Password Password
+	Password Password `json:"passwordHash"`
 
-	PasswordExpires time.Time
+	PasswordExpires time.Time `json:"passwordExpires"`
 }
 
 func (p PasswordInfo) Authenticate(plaintext string) (*oidc.Identity, error) {
@@ -86,7 +86,7 @@ type PasswordInfoRepo interface {
 func (u *PasswordInfo) UnmarshalJSON(data []byte) error {
 	var dec struct {
 		UserID            string    `json:"userId"`
-		PasswordHash      string    `json:"passwordHash"`
+		PasswordHash      []byte    `json:"passwordHash"`
 		PasswordPlaintext string    `json:"passwordPlaintext"`
 		PasswordExpires   time.Time `json:"passwordExpires"`
 	}
@@ -98,7 +98,9 @@ func (u *PasswordInfo) UnmarshalJSON(data []byte) error {
 
 	u.UserID = dec.UserID
 
-	u.PasswordExpires = dec.PasswordExpires
+	if !dec.PasswordExpires.IsZero() {
+		u.PasswordExpires = dec.PasswordExpires
+	}
 
 	if len(dec.PasswordHash) != 0 {
 		if dec.PasswordPlaintext != "" {


### PR DESCRIPTION
PasswordInfos are marshaled when storing them in the database as
part of the local connector. However, the custom unmarsheler
defined could not unmarshal the standard marshling of this struct.

Add a struct tag to the Password field to correct this.

I'd like to see #334 be the long term fix to this. However for now, this works.

Closes #332 

cc @fnordahl 