### PR TITLE
encode pw from client before further processing

### DIFF
--- a/integration/client_api_test.go
+++ b/integration/client_api_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestClientCreate(t *testing.T) {
-	ci := oidc.ClientIdentity{
+	server_ci := oidc.ClientIdentity{
 		Credentials: oidc.ClientCredentials{
 			ID:     "72de74a9",
 			Secret: base64.URLEncoding.EncodeToString([]byte("XXX")),
@@ -23,14 +23,25 @@ func TestClientCreate(t *testing.T) {
 			},
 		},
 	}
-	cis := []oidc.ClientIdentity{ci}
+	client_ci := oidc.ClientIdentity{
+		Credentials: oidc.ClientCredentials{
+			ID:     "72de74a9",
+			Secret: "XXX",
+		},
+		Metadata: oidc.ClientMetadata{
+			RedirectURIs: []url.URL{
+				{Scheme: "https://", Host: "authn.example.com", Path: "/callback"},
+			},
+		},
+	}
+	cis := []oidc.ClientIdentity{server_ci}
 
 	srv, err := mockServer(cis)
 	if err != nil {
 		t.Fatalf("Unexpected error setting up server: %v", err)
 	}
 
-	oidcClient, err := mockClient(srv, ci)
+	oidcClient, err := mockClient(srv, client_ci)
 	if err != nil {
 		t.Fatalf("Unexpected error setting up OIDC client: %v", err)
 	}

--- a/server/http.go
+++ b/server/http.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -434,7 +435,7 @@ func handleTokenFunc(srv OIDCServer) http.HandlerFunc {
 			return
 		}
 
-		creds := oidc.ClientCredentials{ID: user, Secret: password}
+		creds := oidc.ClientCredentials{ID: user, Secret: base64.URLEncoding.EncodeToString([]byte(password))}
 
 		var jwt *jose.JWT
 		var refreshToken string


### PR DESCRIPTION
The changes done in #304 makes dex expect that clients send base64
encoded passwords. I believe that this is an assumption we cannot
make.

Changed the server so it base64 encodes the password from the client
before further processing internally in Dex.

Fixed the tests so they create a mockServer with a base64-encoded
password repo and a mockClient that transmits a plain password.

Partially fixes #335