### PR TITLE
Fix cross compilation

### DIFF
--- a/build
+++ b/build
@@ -2,9 +2,18 @@
 
 source ./env
 
-go install -ldflags="$LD_FLAGS" github.com/coreos/dex/cmd/dex-worker
-go install -ldflags="$LD_FLAGS" github.com/coreos/dex/cmd/dexctl
-go install -ldflags="$LD_FLAGS" github.com/coreos/dex/cmd/dex-overlord
+CMDS=( "dex-worker" "dexctl" "dex-overlord" "gendoc")
+FORMAT='{{ range $i, $dep := .Deps }}{{ $dep }} {{ end }}'
+
+for CMD in ${CMDS[@]}; do
+	TARGET="github.com/coreos/dex/cmd/$CMD"
+	# Install command dependencies. This caches package builds and speeds
+	# up successive builds a lot.
+	go list -f="$FORMAT" $TARGET | xargs go install -ldflags="$LD_FLAGS"
+
+	# Build the actual command.
+	go build -o="bin/$CMD" -ldflags="$LD_FLAGS" $TARGET
+done
+
 go build -o bin/example-app github.com/coreos/dex/examples/app
 go build -o bin/example-cli github.com/coreos/dex/examples/cli
-go install github.com/coreos/dex/cmd/gendoc

--- a/db/conn.go
+++ b/db/conn.go
@@ -9,10 +9,6 @@ import (
 	"github.com/go-gorp/gorp"
 
 	"github.com/coreos/dex/repo"
-
-	// Import database drivers
-	_ "github.com/lib/pq"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 type table struct {

--- a/db/conn_postgres.go
+++ b/db/conn_postgres.go
@@ -1,0 +1,15 @@
+package db
+
+// Register the postgres driver.
+
+import "github.com/lib/pq"
+
+func init() {
+	registerAlreadyExistsChecker(func(err error) bool {
+		sqlErr, ok := err.(*pq.Error)
+		if !ok {
+			return false
+		}
+		return sqlErr.Code == pgErrorCodeUniqueViolation
+	})
+}

--- a/db/conn_sqlite3.go
+++ b/db/conn_sqlite3.go
@@ -1,0 +1,17 @@
+// +build cgo
+
+package db
+
+// Register the sqlite3 driver.
+
+import "github.com/mattn/go-sqlite3"
+
+func init() {
+	registerAlreadyExistsChecker(func(err error) bool {
+		sqlErr, ok := err.(*sqlite3.Error)
+		if !ok {
+			return false
+		}
+		return sqlErr.ExtendedCode == sqlite3.ErrConstraintUnique
+	})
+}

--- a/env
+++ b/env
@@ -1,5 +1,4 @@
 export GOPATH=${PWD}/Godeps/_workspace
-export GOBIN=${PWD}/bin
 
 rm -rf $GOPATH/src/github.com/coreos/dex
 mkdir -p $GOPATH/src/github.com/coreos/
@@ -7,4 +6,6 @@ mkdir -p $GOPATH/src/github.com/coreos/
 # Only attempt to link dex into godeps if it isn't already there
 [ -d $GOPATH/src/github.com/coreos/dex ] || ln -s ${PWD} $GOPATH/src/github.com/coreos/dex
 
-LD_FLAGS="-X main.version=$(./git-version)"
+export VERSION=$(./git-version)
+
+LD_FLAGS="-X main.version=${VERSION}"

--- a/release
+++ b/release
@@ -1,9 +1,16 @@
 #!/bin/bash -e
 
-VERSION=$(./git-version)
-
 GOARCH=amd64
 OSS=( "darwin" "linux" )
+
+
+source ./env
+
+# cannot cross compile when GOBIN is set.
+# See:
+#   https://golang.org/issue/9769
+#   https://golang.org/issue/11778
+unset GOBIN 
 
 for GOOS in ${OSS[@]}; do
 	name=dex-$VERSION-$GOOS-$GOARCH
@@ -11,8 +18,7 @@ for GOOS in ${OSS[@]}; do
 	rm -fr $name.tar.gz $name/
 	mkdir $name
 
-	GOOS=$GOOS GOARCH=$GOARCH ./build
-	cp bin/dexctl $name/
+	GOOS=$GOOS GOARCH=$GOARCH go build -o $name/dexctl -ldflags="$LD_FLAGS" github.com/coreos/dex/cmd/dexctl
 
 	tar -czf $name.tar.gz $name/
 	echo "Created ${name}.tar.gz"


### PR DESCRIPTION
Closes #354. Fixes the release script by protecting the sqlite3 import with a cgo tag.