### PR TITLE
integration: fix email case sensitivity test

### DIFF
--- a/integration/user_api_test.go
+++ b/integration/user_api_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -747,7 +748,7 @@ func TestResendEmailInvitation(t *testing.T) {
 
 			wantEmalier := testEmailer{
 				cantEmail:       tt.cantEmail,
-				lastEmail:       tt.email,
+				lastEmail:       strings.ToLower(tt.email),
 				lastClientID:    "XXX",
 				lastWasInvite:   true,
 				lastRedirectURL: *urlParsed,


### PR DESCRIPTION
#331 was merged after we lowercased all emails in the database (#339). This change fixes the test in #331 to conform to the new standard.