### PR TITLE
Documentation: remove reference to DEX_APP_REDIRECTURL

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -135,7 +135,6 @@ The output of this command is eval'able if you are in bash, and sets the followi
 ```
 DEX_APP_CLIENT_ID
 DEX_APP_CLIENT_SECRET
-DEX_APP_REDIRECTURL
 ```
 
 # Start the Example Web App


### PR DESCRIPTION
It's no longer exists and isn't used anywhere else in the "getting started" guide.

Fixes #365