### PR TITLE
Fix response_type missing param

### DIFF
--- a/server/http_test.go
+++ b/server/http_test.go
@@ -175,6 +175,29 @@ func TestHandleAuthFuncResponsesSingleRedirectURL(t *testing.T) {
 			},
 			wantCode: http.StatusBadRequest,
 		},
+
+		// empty response_type
+		{
+			query: url.Values{
+				"redirect_uri": []string{"http://client.example.com/callback"},
+				"client_id":    []string{"XXX"},
+				"connector_id": []string{"fake"},
+				"scope":        []string{"openid"},
+			},
+			wantCode:     http.StatusFound,
+			wantLocation: "http://client.example.com/callback?error=unsupported_response_type&state=",
+		},
+
+		// empty client_id
+		{
+			query: url.Values{
+				"response_type": []string{"code"},
+				"redirect_uri":  []string{"http://unrecognized.example.com/callback"},
+				"connector_id":  []string{"fake"},
+				"scope":         []string{"openid"},
+			},
+			wantCode: http.StatusBadRequest,
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
This commit fix problem with response_type param, which is required according to OIDC spec, when it is missing.
At now, when connector_id url query param is not set, connector view use response_type that client requested instead of default "code".

Fixes #370