### PR TITLE
add ability to revoke refresh tokens in user API

### DIFF
--- a/functional/repo/client_repo_test.go
+++ b/functional/repo/client_repo_test.go
@@ -24,7 +24,8 @@ var (
 				RedirectURIs: []url.URL{
 					url.URL{
 						Scheme: "https",
-						Host:   "client1.example.com/callback",
+						Host:   "client1.example.com",
+						Path:   "/callback",
 					},
 				},
 			},
@@ -38,7 +39,8 @@ var (
 				RedirectURIs: []url.URL{
 					url.URL{
 						Scheme: "https",
-						Host:   "client2.example.com/callback",
+						Host:   "client2.example.com",
+						Path:   "/callback",
 					},
 				},
 			},

--- a/functional/repo/refresh_repo_test.go
+++ b/functional/repo/refresh_repo_test.go
@@ -1,0 +1,93 @@
+package repo
+
+import (
+	"encoding/base64"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-oidc/oidc"
+	"github.com/go-gorp/gorp"
+	"github.com/kylelemons/godebug/pretty"
+
+	"github.com/coreos/dex/db"
+	"github.com/coreos/dex/refresh"
+	"github.com/coreos/dex/user"
+)
+
+func newRefreshRepo(t *testing.T, users []user.UserWithRemoteIdentities, clients []oidc.ClientIdentity) refresh.RefreshTokenRepo {
+	var dbMap *gorp.DbMap
+	if dsn := os.Getenv("DEX_TEST_DSN"); dsn == "" {
+		dbMap = db.NewMemDB()
+	} else {
+		dbMap = connect(t)
+	}
+	if _, err := db.NewUserRepoFromUsers(dbMap, users); err != nil {
+		t.Fatalf("Unable to add users: %v", err)
+	}
+	if _, err := db.NewClientIdentityRepoFromClients(dbMap, clients); err != nil {
+		t.Fatalf("Unable to add clients: %v", err)
+	}
+	return db.NewRefreshTokenRepo(dbMap)
+}
+
+func TestRefreshTokenRepo(t *testing.T) {
+	clientID := "client1"
+	userID := "user1"
+	clients := []oidc.ClientIdentity{
+		{
+			Credentials: oidc.ClientCredentials{
+				ID:     clientID,
+				Secret: base64.URLEncoding.EncodeToString([]byte("secret-2")),
+			},
+			Metadata: oidc.ClientMetadata{
+				RedirectURIs: []url.URL{
+					url.URL{Scheme: "https", Host: "client1.example.com", Path: "/callback"},
+				},
+			},
+		},
+	}
+	users := []user.UserWithRemoteIdentities{
+		{
+			User: user.User{
+				ID:        userID,
+				Email:     "Email-1@example.com",
+				CreatedAt: time.Now().Truncate(time.Second),
+			},
+			RemoteIdentities: []user.RemoteIdentity{
+				{
+					ConnectorID: "IDPC-1",
+					ID:          "RID-1",
+				},
+			},
+		},
+	}
+
+	repo := newRefreshRepo(t, users, clients)
+	tok, err := repo.Create(userID, clientID)
+	if err != nil {
+		t.Fatalf("failed to create refresh token: %v", err)
+	}
+	if tokUserID, err := repo.Verify(clientID, tok); err != nil {
+		t.Errorf("Could not verify token: %v", err)
+	} else if tokUserID != userID {
+		t.Errorf("Verified token returned wrong user id, want=%s, got=%s", userID, tokUserID)
+	}
+
+	if userClients, err := repo.ClientsWithRefreshTokens(userID); err != nil {
+		t.Errorf("Failed to get the list of clients the user was logged into: %v", err)
+	} else {
+		if diff := pretty.Compare(userClients, clients); diff == "" {
+			t.Errorf("Clients user logged into: want did not equal got %s", diff)
+		}
+	}
+
+	if err := repo.RevokeTokensForClient(userID, clientID); err != nil {
+		t.Errorf("Failed to revoke refresh token: %v", err)
+	}
+
+	if _, err := repo.Verify(clientID, tok); err == nil {
+		t.Errorf("Token which should have been revoked was verified")
+	}
+}

--- a/refresh/repo.go
+++ b/refresh/repo.go
@@ -3,6 +3,8 @@ package refresh
 import (
 	"crypto/rand"
 	"errors"
+
+	"github.com/coreos/go-oidc/oidc"
 )
 
 const (
@@ -47,4 +49,10 @@ type RefreshTokenRepo interface {
 
 	// Revoke deletes the refresh token if the token belongs to the given userID.
 	Revoke(userID, token string) error
+
+	// RevokeTokensForClient revokes all tokens issued for the userID for the provided client.
+	RevokeTokensForClient(userID, clientID string) error
+
+	// ClientsWithRefreshTokens returns a list of all clients the user has an outstanding client with.
+	ClientsWithRefreshTokens(userID string) ([]oidc.ClientIdentity, error)
 }

--- a/schema/generator
+++ b/schema/generator
@@ -33,8 +33,15 @@ fi
 
 $GENDOC --f $IN --o $DOC
 
-# See schema/generator_import.go for instructions on updating the dependency
-PKG="google.golang.org/api/google-api-go-generator"
+# Though google-api-go-generator is a main, dex vendors the app using the same
+# tool it uses to vendor third party packages. Hence, it can be found in the
+# "vendor" directory.
+#
+# This vendoring is currently done with godep, but may change if/when we move to
+# another tool.
+#
+# See schema/generator_import.go for instructions on updating the dependency.
+PKG="github.com/coreos/dex/vendor/google.golang.org/api/google-api-go-generator"
 
 # First, write the discovery document into a go file so it can be served statically by the API
 cat << EOF > "${OUT}"
@@ -53,7 +60,7 @@ echo -n '`' >> "${OUT}"
 # Now build google-api-go-generator - we vendor so this is consistently reproducible
 GEN_PATH="bin/google-api-go-generator"
 if [ ! -f ${GEN_PATH} ]; then
-	GOPATH="${PWD}/Godeps/_workspace" go build -o ${GEN_PATH} ${PKG}
+    go build -o ${GEN_PATH} ${PKG}
 fi
 
 # Build the bindings

--- a/schema/workerschema/README.md
+++ b/schema/workerschema/README.md
@@ -59,6 +59,31 @@ __Version:__ v1
 }
 ```
 
+### RefreshClient
+
+A client with associated public metadata.
+
+```
+{
+    clientID: string,
+    clientName: string,
+    clientURI: string,
+    logoURI: string
+}
+```
+
+### RefreshClientList
+
+
+
+```
+{
+    clients: [
+        RefreshClient
+    ]
+}
+```
+
 ### ResendEmailInvitationRequest
 
 
@@ -164,6 +189,58 @@ __Version:__ v1
 
 
 ## Paths
+
+
+### GET /account/{userid}/refresh
+
+> __Summary__
+
+> List RefreshClient
+
+> __Description__
+
+> List all clients that hold refresh tokens for the authenticated user.
+
+
+> __Parameters__
+
+> |Name|Located in|Description|Required|Type|
+|:-----|:-----|:-----|:-----|:-----|
+| userid | path |  | Yes | string | 
+
+
+> __Responses__
+
+> |Code|Description|Type|
+|:-----|:-----|:-----|
+| 200 |  | [RefreshClientList](#refreshclientlist) |
+| default | Unexpected error |  |
+
+
+### DELETE /account/{userid}/refresh/{clientid}
+
+> __Summary__
+
+> Revoke Clients
+
+> __Description__
+
+> Revoke all refresh tokens issues to the client for the authenticated user.
+
+
+> __Parameters__
+
+> |Name|Located in|Description|Required|Type|
+|:-----|:-----|:-----|:-----|:-----|
+| clientid | path |  | Yes | string | 
+| userid | path |  | Yes | string | 
+
+
+> __Responses__
+
+> |Code|Description|Type|
+|:-----|:-----|:-----|
+| default | Unexpected error |  |
 
 
 ### GET /clients

--- a/schema/workerschema/v1-gen.go
+++ b/schema/workerschema/v1-gen.go
@@ -14,12 +14,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"google.golang.org/api/googleapi"
 	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"google.golang.org/api/googleapi"
 )
 
 // Always reference these packages, just in case the auto-generated code
@@ -45,6 +46,7 @@ func New(client *http.Client) (*Service, error) {
 	}
 	s := &Service{client: client, BasePath: basePath}
 	s.Clients = NewClientsService(s)
+	s.RefreshClient = NewRefreshClientService(s)
 	s.Users = NewUsersService(s)
 	return s, nil
 }
@@ -55,6 +57,8 @@ type Service struct {
 
 	Clients *ClientsService
 
+	RefreshClient *RefreshClientService
+
 	Users *UsersService
 }
 
@@ -64,6 +68,15 @@ func NewClientsService(s *Service) *ClientsService {
 }
 
 type ClientsService struct {
+	s *Service
+}
+
+func NewRefreshClientService(s *Service) *RefreshClientService {
+	rs := &RefreshClientService{s: s}
+	return rs
+}
+
+type RefreshClientService struct {
 	s *Service
 }
 
@@ -100,6 +113,20 @@ type Error struct {
 	Error string `json:"error,omitempty"`
 
 	Error_description string `json:"error_description,omitempty"`
+}
+
+type RefreshClient struct {
+	ClientID string `json:"clientID,omitempty"`
+
+	ClientName string `json:"clientName,omitempty"`
+
+	ClientURI string `json:"clientURI,omitempty"`
+
+	LogoURI string `json:"logoURI,omitempty"`
+}
+
+type RefreshClientList struct {
+	Clients []*RefreshClient `json:"clients,omitempty"`
 }
 
 type ResendEmailInvitationRequest struct {
@@ -302,6 +329,154 @@ func (c *ClientsListCall) Do() (*ClientPage, error) {
 	//   "path": "clients",
 	//   "response": {
 	//     "$ref": "ClientPage"
+	//   }
+	// }
+
+}
+
+// method id "dex.Client.Revoke":
+
+type ClientsRevokeCall struct {
+	s        *Service
+	userid   string
+	clientid string
+	opt_     map[string]interface{}
+}
+
+// Revoke: Revoke all refresh tokens issues to the client for the
+// authenticated user.
+func (r *ClientsService) Revoke(userid string, clientid string) *ClientsRevokeCall {
+	c := &ClientsRevokeCall{s: r.s, opt_: make(map[string]interface{})}
+	c.userid = userid
+	c.clientid = clientid
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ClientsRevokeCall) Fields(s ...googleapi.Field) *ClientsRevokeCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ClientsRevokeCall) Do() error {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "account/{userid}/refresh/{clientid}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("DELETE", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"userid":   c.userid,
+		"clientid": c.clientid,
+	})
+	req.Header.Set("User-Agent", "google-api-go-client/0.5")
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return err
+	}
+	return nil
+	// {
+	//   "description": "Revoke all refresh tokens issues to the client for the authenticated user.",
+	//   "httpMethod": "DELETE",
+	//   "id": "dex.Client.Revoke",
+	//   "parameterOrder": [
+	//     "userid",
+	//     "clientid"
+	//   ],
+	//   "parameters": {
+	//     "clientid": {
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "userid": {
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "account/{userid}/refresh/{clientid}"
+	// }
+
+}
+
+// method id "dex.Client.List":
+
+type RefreshClientListCall struct {
+	s      *Service
+	userid string
+	opt_   map[string]interface{}
+}
+
+// List: List all clients that hold refresh tokens for the authenticated
+// user.
+func (r *RefreshClientService) List(userid string) *RefreshClientListCall {
+	c := &RefreshClientListCall{s: r.s, opt_: make(map[string]interface{})}
+	c.userid = userid
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *RefreshClientListCall) Fields(s ...googleapi.Field) *RefreshClientListCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *RefreshClientListCall) Do() (*RefreshClientList, error) {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "account/{userid}/refresh")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"userid": c.userid,
+	})
+	req.Header.Set("User-Agent", "google-api-go-client/0.5")
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *RefreshClientList
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "List all clients that hold refresh tokens for the authenticated user.",
+	//   "httpMethod": "GET",
+	//   "id": "dex.Client.List",
+	//   "parameterOrder": [
+	//     "userid"
+	//   ],
+	//   "parameters": {
+	//     "userid": {
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "account/{userid}/refresh",
+	//   "response": {
+	//     "$ref": "RefreshClientList"
 	//   }
 	// }
 

--- a/schema/workerschema/v1-json.go
+++ b/schema/workerschema/v1-json.go
@@ -55,6 +55,37 @@ const DiscoveryJSON = `{
         }
       }
     },
+	"RefreshClient": {
+      "id": "Client",
+      "type": "object",
+	  "description": "A client with associated public metadata.",
+      "properties": {
+		"clientID": {
+			"type": "string"
+		},
+		"clientName": {
+			"type": "string"
+		},
+		"logoURI": {
+			"type": "string"
+		},
+		"clientURI": {
+			"type": "string"
+		}
+      }
+	},
+	"RefreshClientList": {
+      "id": "RefreshClientList",
+      "type": "object",
+      "properties": {
+        "clients": {
+          "type": "array",
+          "items": {
+            "$ref": "RefreshClient"
+          }
+        }
+      }
+	},
     "ClientWithSecret": {
       "id": "Client",
       "type": "object",
@@ -241,6 +272,27 @@ const DiscoveryJSON = `{
           "response": {
             "$ref": "ClientWithSecret"
           }
+        },
+        "Revoke": {
+          "id": "dex.Client.Revoke",
+          "description": "Revoke all refresh tokens issues to the client for the authenticated user.",
+          "httpMethod": "DELETE",
+          "path": "account/{userid}/refresh/{clientid}",
+          "parameterOrder": [
+            "userid","clientid"
+          ],
+          "parameters": {
+            "clientid": {
+              "type": "string",
+              "required": true,
+              "location": "path"
+            },
+            "userid": {
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
+          }
         }
       }
     },
@@ -338,6 +390,29 @@ const DiscoveryJSON = `{
           },
           "response": {
             "$ref": "ResendEmailInvitationResponse"
+          }
+        }
+      }
+    },
+    "RefreshClient": {
+      "methods": {
+        "List": {
+          "id": "dex.Client.List",
+          "description": "List all clients that hold refresh tokens for the authenticated user.",
+          "httpMethod": "GET",
+          "path": "account/{userid}/refresh",
+          "parameters": {
+            "userid": {
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "userid"
+          ],
+          "response": {
+            "$ref": "RefreshClientList"
           }
         }
       }

--- a/schema/workerschema/v1.json
+++ b/schema/workerschema/v1.json
@@ -49,6 +49,37 @@
         }
       }
     },
+	"RefreshClient": {
+      "id": "Client",
+      "type": "object",
+	  "description": "A client with associated public metadata.",
+      "properties": {
+		"clientID": {
+			"type": "string"
+		},
+		"clientName": {
+			"type": "string"
+		},
+		"logoURI": {
+			"type": "string"
+		},
+		"clientURI": {
+			"type": "string"
+		}
+      }
+	},
+	"RefreshClientList": {
+      "id": "RefreshClientList",
+      "type": "object",
+      "properties": {
+        "clients": {
+          "type": "array",
+          "items": {
+            "$ref": "RefreshClient"
+          }
+        }
+      }
+	},
     "ClientWithSecret": {
       "id": "Client",
       "type": "object",
@@ -235,6 +266,27 @@
           "response": {
             "$ref": "ClientWithSecret"
           }
+        },
+        "Revoke": {
+          "id": "dex.Client.Revoke",
+          "description": "Revoke all refresh tokens issues to the client for the authenticated user.",
+          "httpMethod": "DELETE",
+          "path": "account/{userid}/refresh/{clientid}",
+          "parameterOrder": [
+            "userid","clientid"
+          ],
+          "parameters": {
+            "clientid": {
+              "type": "string",
+              "required": true,
+              "location": "path"
+            },
+            "userid": {
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
+          }
         }
       }
     },
@@ -332,6 +384,29 @@
           },
           "response": {
             "$ref": "ResendEmailInvitationResponse"
+          }
+        }
+      }
+    },
+    "RefreshClient": {
+      "methods": {
+        "List": {
+          "id": "dex.Client.List",
+          "description": "List all clients that hold refresh tokens for the authenticated user.",
+          "httpMethod": "GET",
+          "path": "account/{userid}/refresh",
+          "parameters": {
+            "userid": {
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "userid"
+          ],
+          "response": {
+            "$ref": "RefreshClientList"
           }
         }
       }

--- a/server/config.go
+++ b/server/config.go
@@ -160,6 +160,7 @@ func (cfg *SingleServerConfig) Configure(srv *Server) error {
 	srv.SessionManager = sm
 	srv.RefreshTokenRepo = refTokRepo
 	srv.HealthChecks = append(srv.HealthChecks, db.NewHealthChecker(dbMap))
+	srv.dbMap = dbMap
 	return nil
 }
 
@@ -253,6 +254,7 @@ func (cfg *MultiServerConfig) Configure(srv *Server) error {
 	srv.SessionManager = sm
 	srv.RefreshTokenRepo = refreshTokenRepo
 	srv.HealthChecks = append(srv.HealthChecks, db.NewHealthChecker(dbc))
+	srv.dbMap = dbc
 	return nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/coreos/go-oidc/oauth2"
 	"github.com/coreos/go-oidc/oidc"
 	"github.com/coreos/pkg/health"
+	"github.com/go-gorp/gorp"
 	"github.com/jonboulle/clockwork"
 
 	"github.com/coreos/dex/client"
@@ -77,6 +78,7 @@ type Server struct {
 	EnableRegistration             bool
 	EnableClientRegistration       bool
 
+	dbMap            *gorp.DbMap
 	localConnectorID string
 }
 
@@ -270,12 +272,10 @@ func (s *Server) HTTPHandler() http.Handler {
 	clientPath, clientHandler := registerClientResource(apiBasePath, s.ClientIdentityRepo)
 	mux.Handle(path.Join(apiBasePath, clientPath), s.NewClientTokenAuthHandler(clientHandler))
 
-	usersAPI := usersapi.NewUsersAPI(s.UserManager, s.ClientIdentityRepo, s.UserEmailer, s.localConnectorID)
+	usersAPI := usersapi.NewUsersAPI(s.dbMap, s.UserManager, s.UserEmailer, s.localConnectorID)
 	handler := NewUserMgmtServer(usersAPI, s.JWTVerifierFactory(), s.UserManager, s.ClientIdentityRepo).HTTPHandler()
-	path := path.Join(apiBasePath, UsersSubTree)
 
-	mux.Handle(path, handler)
-	mux.Handle(path+"/", handler)
+	mux.Handle(apiBasePath+"/", handler)
 
 	return http.Handler(mux)
 }

--- a/server/user.go
+++ b/server/user.go
@@ -30,6 +30,9 @@ var (
 	UsersGetEndpoint              = addBasePath(UsersSubTree + "/:id")
 	UsersDisableEndpoint          = addBasePath(UsersSubTree + "/:id/disable")
 	UsersResendInvitationEndpoint = addBasePath(UsersSubTree + "/:id/resend-invitation")
+	AccountSubTree                = "/account"
+	AccountListRefreshTokens      = addBasePath(AccountSubTree + "/:userid/refresh")
+	AccountRevokeRefreshToken     = addBasePath(AccountSubTree + "/:userid/refresh/:clientid")
 )
 
 type UserMgmtServer struct {
@@ -52,12 +55,24 @@ func (s *UserMgmtServer) HTTPHandler() http.Handler {
 	r := httprouter.New()
 	r.RedirectTrailingSlash = false
 	r.RedirectFixedPath = false
-	r.GET(UsersListEndpoint, s.authAPIHandle(s.listUsers))
-	r.POST(UsersCreateEndpoint, s.authAPIHandle(s.createUser))
-	r.POST(UsersDisableEndpoint, s.authAPIHandle(s.disableUser))
-	r.GET(UsersGetEndpoint, s.authAPIHandle(s.getUser))
-	r.POST(UsersResendInvitationEndpoint, s.authAPIHandle(s.resendInvitationEmail))
+
+	r.GET(UsersListEndpoint, s.authAdminUser(s.listUsers))
+	r.POST(UsersCreateEndpoint, s.authAdminUser(s.createUser))
+	r.POST(UsersDisableEndpoint, s.authAdminUser(s.disableUser))
+	r.GET(UsersGetEndpoint, s.authAdminUser(s.getUser))
+	r.POST(UsersResendInvitationEndpoint, s.authAdminUser(s.resendInvitationEmail))
+
+	r.GET(AccountListRefreshTokens, s.authAccount(s.listClientsWithRefreshTokens))
+	r.DELETE(AccountRevokeRefreshToken, s.authAccount(s.revokeRefreshTokensForClient))
 	return r
+}
+
+func (s *UserMgmtServer) authAdminUser(handle authedHandle) httprouter.Handle {
+	return s.authAPIHandle(handle, true)
+}
+
+func (s *UserMgmtServer) authAccount(handle authedHandle) httprouter.Handle {
+	return s.authAPIHandle(handle, false)
 }
 
 // authedHandle is an HTTP handle which requires requests to be authenticated as an admin user.
@@ -65,11 +80,21 @@ type authedHandle func(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 
 // authAPIHandle is a middleware function with authenticates an HTTP request before passing
 // it along to the authedHandle.
-func (s *UserMgmtServer) authAPIHandle(handle authedHandle) httprouter.Handle {
+//
+// The authorization checks for an ID token bearer token in the request header, requiring the
+// audience (aud claim) be a client ID of an admin client.
+//
+// If requiresAdmin is true, the subject identifier (sub claim) of the ID token provided must be
+// that of an admin user.
+func (s *UserMgmtServer) authAPIHandle(handle authedHandle, requiresAdmin bool) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		creds, err := s.getCreds(r)
 		if err != nil {
 			s.writeError(w, err)
+			return
+		}
+		if creds.User.Disabled || (requiresAdmin && !creds.User.Admin) {
+			s.writeError(w, api.ErrorUnauthorized)
 			return
 		}
 		handle(w, r, ps, creds)
@@ -189,6 +214,23 @@ func (s *UserMgmtServer) resendInvitationEmail(w http.ResponseWriter, r *http.Re
 	}
 
 	writeResponseWithBody(w, http.StatusOK, resendEmailInvitationResponse)
+}
+
+func (s *UserMgmtServer) listClientsWithRefreshTokens(w http.ResponseWriter, r *http.Request, ps httprouter.Params, creds api.Creds) {
+	clients, err := s.api.ListClientsWithRefreshTokens(creds, ps.ByName("userid"))
+	if err != nil {
+		s.writeError(w, err)
+		return
+	}
+	writeResponseWithBody(w, http.StatusOK, schema.RefreshClientList{Clients: clients})
+}
+
+func (s *UserMgmtServer) revokeRefreshTokensForClient(w http.ResponseWriter, r *http.Request, ps httprouter.Params, creds api.Creds) {
+	if err := s.api.RevokeRefreshTokensForClient(creds, ps.ByName("userid"), ps.ByName("clientid")); err != nil {
+		s.writeError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK) // NOTE (ericchiang): http.StatusNoContent or return an empty JSON object?
 }
 
 func (s *UserMgmtServer) writeError(w http.ResponseWriter, err error) {


### PR DESCRIPTION
I'm opening this in place of #329 because last time I forced a push for #329 all the inline comments disappeared.

This PR adds API endpoints for listening clients with refresh tokens and revoking refresh tokens. Work needed for #261 (note we've considered splitting the UI work from the API work needed for #261).