### PR TITLE
remove passwordInfos from local connector

### DIFF
--- a/connector/config_repo_test.go
+++ b/connector/config_repo_test.go
@@ -60,23 +60,9 @@ func TestNewConnectorConfigFromMap(t *testing.T) {
 			m: map[string]interface{}{
 				"type": "local",
 				"id":   "foo",
-				"passwordInfos": []map[string]string{
-					{"userId": "abc", "passwordHash": "UElORw=="}, // []byte is base64 encoded when using json.Marshasl
-					{"userId": "271", "passwordPlaintext": "pong"},
-				},
 			},
 			want: &LocalConnectorConfig{
 				ID: "foo",
-				PasswordInfos: []user.PasswordInfo{
-					user.PasswordInfo{
-						UserID:   "abc",
-						Password: user.Password("PING"),
-					},
-					user.PasswordInfo{
-						UserID:   "271",
-						Password: user.Password("PONG"),
-					},
-				},
 			},
 		},
 		{
@@ -111,12 +97,6 @@ func TestNewConnectorConfigFromMap(t *testing.T) {
 
 func TestNewConnectorConfigFromMapFail(t *testing.T) {
 	tests := []map[string]interface{}{
-		// invalid local connector
-		map[string]interface{}{
-			"type":          "local",
-			"passwordInfos": "invalid",
-		},
-
 		// no type
 		map[string]interface{}{
 			"id": "bar",

--- a/connector/connector_local.go
+++ b/connector/connector_local.go
@@ -21,8 +21,7 @@ func init() {
 }
 
 type LocalConnectorConfig struct {
-	ID            string              `json:"id"`
-	PasswordInfos []user.PasswordInfo `json:"passwordInfos"`
+	ID string `json:"id"`
 }
 
 func (cfg *LocalConnectorConfig) ConnectorID() string {

--- a/integration/oidc_test.go
+++ b/integration/oidc_test.go
@@ -113,7 +113,7 @@ func TestHTTPExchangeTokenRefreshToken(t *testing.T) {
 	}
 
 	cfg := &connector.LocalConnectorConfig{
-		PasswordInfos: []user.PasswordInfo{passwordInfo},
+		ID: "local",
 	}
 
 	ci := oidc.ClientIdentity{
@@ -127,6 +127,10 @@ func TestHTTPExchangeTokenRefreshToken(t *testing.T) {
 	cir, err := db.NewClientIdentityRepoFromClients(dbMap, []oidc.ClientIdentity{ci})
 	if err != nil {
 		t.Fatalf("Failed to create client identity repo: " + err.Error())
+	}
+	passwordInfoRepo, err := db.NewPasswordInfoRepoFromPasswordInfos(db.NewMemDB(), []user.PasswordInfo{passwordInfo})
+	if err != nil {
+		t.Fatalf("Failed to create password info repo: %v", err)
 	}
 
 	issuerURL := url.URL{Scheme: "http", Host: "server.example.com"}
@@ -153,7 +157,6 @@ func TestHTTPExchangeTokenRefreshToken(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	passwordInfoRepo := db.NewPasswordInfoRepo(db.NewMemDB())
 	refreshTokenRepo := refreshtest.NewTestRefreshTokenRepo()
 
 	srv := &server.Server{

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coreos/dex/user"
+	"github.com/kylelemons/godebug/pretty"
+)
+
+func TestLoadUsers(t *testing.T) {
+	tests := []struct {
+		// The raw JSON file
+		raw      string
+		expUsers []user.UserWithRemoteIdentities
+		// userid -> plaintext password
+		expPasswds map[string]string
+	}{
+		{
+			raw: `[
+			    {
+			        "id": "elroy-id",
+			        "email": "elroy77@example.com",
+			        "displayName": "Elroy Jonez",
+			        "password": "bones",
+			        "remoteIdentities": [
+			            {
+			                "connectorId": "local",
+			                "id": "elroy-id"
+			            }
+			        ]
+			    }
+			]`,
+			expUsers: []user.UserWithRemoteIdentities{
+				{
+					User: user.User{
+						ID:          "elroy-id",
+						Email:       "elroy77@example.com",
+						DisplayName: "Elroy Jonez",
+					},
+					RemoteIdentities: []user.RemoteIdentity{
+						{
+							ConnectorID: "local",
+							ID:          "elroy-id",
+						},
+					},
+				},
+			},
+			expPasswds: map[string]string{
+				"elroy-id": "bones",
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		users, pwInfos, err := loadUsersFromReader(strings.NewReader(tt.raw))
+		if err != nil {
+			t.Errorf("case %d: failed to load user: %v", i, err)
+			return
+		}
+
+		if diff := pretty.Compare(tt.expUsers, users); diff != "" {
+			t.Errorf("case: %d: wantUsers!=gotUsers: %s", i, diff)
+		}
+
+		// For each password info loaded, verify the password.
+		for _, pwInfo := range pwInfos {
+			expPW, ok := tt.expPasswds[pwInfo.UserID]
+			if !ok {
+				t.Errorf("no password entry for %s", pwInfo.UserID)
+				continue
+			}
+			if _, err := pwInfo.Authenticate(expPW); err != nil {
+				t.Errorf("case %d: user %s's password did not match", i, pwInfo.UserID)
+			}
+		}
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -178,19 +178,6 @@ func (s *Server) AddConnector(cfg connector.ConnectorConfig) error {
 			UserRepo:         s.UserRepo,
 			PasswordInfoRepo: s.PasswordInfoRepo,
 		})
-
-		localCfg, ok := cfg.(*connector.LocalConnectorConfig)
-		if !ok {
-			return errors.New("config for LocalConnector not a LocalConnectorConfig?")
-		}
-
-		if len(localCfg.PasswordInfos) > 0 {
-			err := user.LoadPasswordInfos(s.PasswordInfoRepo,
-				localCfg.PasswordInfos)
-			if err != nil {
-				return err
-			}
-		}
 	}
 
 	log.Infof("Loaded IdP connector: id=%s type=%s", connectorID, cfg.ConnectorType())

--- a/static/fixtures/connectors.json.sample
+++ b/static/fixtures/connectors.json.sample
@@ -1,17 +1,7 @@
 [
 	{
 		"type": "local",
-		"id": "local",
-		"passwordInfos": [
-			{
-				"userId":"elroy-id",
-				"passwordPlaintext": "bones"
-			},
-			{
-				"userId":"penny",
-				"passwordPlaintext": "kibble"
-			}
-		]
+		"id": "local"
 	},
 	{
 		"type": "oidc",

--- a/static/fixtures/users.json.sample
+++ b/static/fixtures/users.json.sample
@@ -1,10 +1,9 @@
 [
     {
-        "user":{
-            "id": "elroy-id",
-            "email": "elroy77@example.com",
-            "displayName": "Elroy Jonez"
-        },
+        "id": "elroy-id",
+        "email": "elroy77@example.com",
+        "displayName": "Elroy Jonez",
+        "password": "bones",
         "remoteIdentities": [
             {
                 "connectorId": "local",


### PR DESCRIPTION
In --no-db mode, load passwords from the users file instead of the
connectors file. This allows us to remove the password infos field
from the local connector and stop loading them during connector
registration, a case that was causing panics when using a real
database (see #286).

Fixes #286
Closes #340