### PR TITLE
bugfix: make getCreds work for non-admins

### DIFF
--- a/server/user.go
+++ b/server/user.go
@@ -88,7 +88,7 @@ type authedHandle func(w http.ResponseWriter, r *http.Request, ps httprouter.Par
 // that of an admin user.
 func (s *UserMgmtServer) authAPIHandle(handle authedHandle, requiresAdmin bool) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-		creds, err := s.getCreds(r)
+		creds, err := s.getCreds(r, requiresAdmin)
 		if err != nil {
 			s.writeError(w, err)
 			return
@@ -243,7 +243,7 @@ func (s *UserMgmtServer) writeError(w http.ResponseWriter, err error) {
 	writeAPIError(w, http.StatusInternalServerError, newAPIError(errorServerError, err.Error()))
 }
 
-func (s *UserMgmtServer) getCreds(r *http.Request) (api.Creds, error) {
+func (s *UserMgmtServer) getCreds(r *http.Request, requiresAdmin bool) (api.Creds, error) {
 	token, err := oidc.ExtractBearerToken(r)
 	if err != nil {
 		log.Errorf("userMgmtServer: GetCreds err: %q", err)
@@ -300,7 +300,7 @@ func (s *UserMgmtServer) getCreds(r *http.Request) (api.Creds, error) {
 		log.Errorf("userMgmtServer: GetCreds err: %q", err)
 		return api.Creds{}, err
 	}
-	if !isAdmin {
+	if requiresAdmin && !isAdmin {
 		return api.Creds{}, api.ErrorForbidden
 	}
 


### PR DESCRIPTION
In #386, the intention was to expose some of this functionality to _ordinary users_. However, [down the road](https://github.com/coreos/dex/pull/386/files#diff-fb49ec733096f07f50a1275c54e5889cR303), `getCreds()` would fail if the user wasn't _admin_:

```go
 	if !isAdmin {
 		return api.Creds{}, api.ErrorForbidden
 	}
```