### PR TITLE
*: don't go get vet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
 
 install:
   - go get golang.org/x/tools/cmd/cover
-  - go get golang.org/x/tools/cmd/vet
   - docker pull quay.io/coreos/postgres
   - docker pull osixia/openldap
 


### PR DESCRIPTION
It's part of the standard tooling and no longer lives in
golang.org/x/tools.

See https://golang.org/cl/20810