### PR TITLE
db: print better error messages for invalid input

### DIFF
--- a/db/user.go
+++ b/db/user.go
@@ -451,6 +451,12 @@ func (u *userModel) user() (user.User, error) {
 }
 
 func newUserModel(u *user.User) (*userModel, error) {
+	if u.ID == "" {
+		return nil, fmt.Errorf("user is missing ID field")
+	}
+	if u.Email == "" {
+		return nil, fmt.Errorf("user %s is missing email field", u.ID)
+	}
 	um := userModel{
 		ID:            u.ID,
 		DisplayName:   u.DisplayName,


### PR DESCRIPTION
When client secrets are not base64 encoded, print an error message
that's not a generic base64 decode error:

	client secrets must be base64 decodable. See issue #337.
	Please consider replaceing "secret" with "c2VjcmV0"

When a user file is missing a mandatory field print an error message.

	Unable to build Server: user elroy-foo is missing email field

For #400