### PR TITLE
contrib/k8s: YAML brevity via references, minimum resource requests

### DIFF
--- a/contrib/k8s/dex-overlord.yaml
+++ b/contrib/k8s/dex-overlord.yaml
@@ -62,11 +62,18 @@ spec:
             - containerPort: 5557
               name: overlord-port
             livenessProbe:
-              httpGet:
+              httpGet: &health
                 path: /health
                 port: 5557
-              initialDelaySeconds: 16
+              initialDelaySeconds: 15
               timeoutSeconds: 1
+            readinessProbe:
+              httpGet: *health
+              initialDelaySeconds: 5
+              timeoutSeconds: 5
+              periodSeconds: 5
+            resources:
+              requests: { cpu: 500m, memory: 512Mi }
             volumeMounts:
               - name: connectors
                 mountPath: /etc/dex-connectors

--- a/contrib/k8s/dex-worker.yaml
+++ b/contrib/k8s/dex-worker.yaml
@@ -40,19 +40,19 @@ spec:
             - containerPort: 5556
               name: worker-port
             readinessProbe:
-              httpGet:
+              httpGet: &health
                 path: /health
                 port: 5556
               timeoutSeconds: 1
               periodSeconds: 2
             livenessProbe:
-              httpGet:
-                path: /health
-                port: 5556
+              httpGet: *health
               initialDelaySeconds: 15
               timeoutSeconds: 1
-              # In production, you will likely want to include your own trusted
-              # /etc/ca-certificates and /etc/ssl in your container.
+            resources:
+              requests: { cpu: 200m, memory: 256Mi }
+            # In production, you will likely want to include your own trusted
+            # /etc/ca-certificates and /etc/ssl in your container.
             volumeMounts:
               - name: ca
                 mountPath: /etc/ca-certificates


### PR DESCRIPTION
- Add resource requests for deployments
- Add readiness probe for master
- Use YAML references for easier maintenance/readability