### PR TITLE
Cross client work 

### DIFF
--- a/admin/api.go
+++ b/admin/api.go
@@ -141,7 +141,7 @@ func (a *AdminAPI) CreateClient(req adminschema.ClientCreateRequest) (adminschem
 	}
 
 	// metadata is guaranteed to have at least one redirect_uri by earlier validation.
-	creds, err := a.clientManager.New(cli)
+	creds, err := a.clientManager.New(cli, nil)
 	if err != nil {
 		return adminschema.ClientCreateResponse{}, mapError(err)
 	}

--- a/admin/api.go
+++ b/admin/api.go
@@ -141,7 +141,10 @@ func (a *AdminAPI) CreateClient(req adminschema.ClientCreateRequest) (adminschem
 	}
 
 	// metadata is guaranteed to have at least one redirect_uri by earlier validation.
-	creds, err := a.clientManager.New(cli, nil)
+	creds, err := a.clientManager.New(cli, &clientmanager.ClientOptions{
+		TrustedPeers: req.Client.TrustedPeers,
+	})
+
 	if err != nil {
 		return adminschema.ClientCreateResponse{}, mapError(err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -15,6 +15,7 @@ import (
 )
 
 var (
+	ErrorInvalidClientID       = errors.New("not a valid client ID")
 	ErrorInvalidRedirectURL    = errors.New("not a valid redirect url for the given client")
 	ErrorCantChooseRedirectURL = errors.New("must provide a redirect url; client has many")
 	ErrorNoValidRedirectURLs   = errors.New("no valid redirect URLs for this client.")
@@ -60,6 +61,12 @@ type ClientRepo interface {
 	New(tx repo.Transaction, client Client) (*oidc.ClientCredentials, error)
 
 	Update(tx repo.Transaction, client Client) error
+
+	// GetTrustedPeers returns the list of clients authorized to mint ID token for the given client.
+	GetTrustedPeers(tx repo.Transaction, clientID string) ([]string, error)
+
+	// SetTrustedPeers sets the list of clients authorized to mint ID token for the given client.
+	SetTrustedPeers(tx repo.Transaction, clientID string, clientIDs []string) error
 }
 
 // ValidRedirectURL returns the passed in URL if it is present in the redirectURLs list, and returns an error otherwise.

--- a/client/manager/manager_test.go
+++ b/client/manager/manager_test.go
@@ -132,7 +132,7 @@ func TestAuthenticate(t *testing.T) {
 	cli := client.Client{
 		Metadata: cm,
 	}
-	cc, err := f.mgr.New(cli)
+	cc, err := f.mgr.New(cli, nil)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/cmd/dexctl/driver_db.go
+++ b/cmd/dexctl/driver_db.go
@@ -34,7 +34,7 @@ func (d *dbDriver) NewClient(meta oidc.ClientMetadata) (*oidc.ClientCredentials,
 	cli := client.Client{
 		Metadata: meta,
 	}
-	return d.ciManager.New(cli)
+	return d.ciManager.New(cli, nil)
 }
 
 func (d *dbDriver) ConnectorConfigs() ([]connector.ConnectorConfig, error) {

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-gorp/gorp"
-	"github.com/rubenv/sql-migrate"
+	migrate "github.com/rubenv/sql-migrate"
 
 	"github.com/coreos/dex/db/migrations"
 )

--- a/db/migrate_sqlite3.go
+++ b/db/migrate_sqlite3.go
@@ -70,4 +70,10 @@ CREATE TABLE session_key (
     expires_at bigint,
     stale integer
 );
+
+CREATE TABLE trusted_peers (
+    client_id text NOT NULL,
+    trusted_client_id text NOT NULL
+);
+
 `

--- a/db/migrations/0012_add_cross_client_authorizers.sql
+++ b/db/migrations/0012_add_cross_client_authorizers.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS "trusted_peers" (
+       "client_id" text not null,
+       "trusted_client_id" text not null,
+       primary key ("client_id", "trusted_client_id")) ;

--- a/db/migrations/assets.go
+++ b/db/migrations/assets.go
@@ -72,5 +72,11 @@ var PostgresMigrations migrate.MigrationSource = &migrate.MemoryMigrationSource{
 				"-- +migrate Up\n\n-- This migration is a fix for a bug that allowed duplicate emails if they used different cases (see #338).\n-- When migrating, dex will not take the liberty of deleting rows for duplicate cases. Instead it will\n-- raise an exception and call for an admin to remove duplicates manually.\n\nCREATE OR REPLACE FUNCTION raise_exp() RETURNS VOID AS $$\nBEGIN\n     RAISE EXCEPTION 'Found duplicate emails when using case insensitive comparision, cannot perform migration.';\nEND;\n$$ LANGUAGE plpgsql;\n\nSELECT LOWER(email),\n    COUNT(email),\n    CASE\n        WHEN COUNT(email) > 1 THEN raise_exp()\n        ELSE NULL\n    END\nFROM authd_user\nGROUP BY LOWER(email);\n\nUPDATE authd_user SET email = LOWER(email);\n",
 			},
 		},
+		{
+			Id: "0012_add_cross_client_authorizers.sql",
+			Up: []string{
+				"-- +migrate Up\nCREATE TABLE IF NOT EXISTS \"trusted_peers\" (\n       \"client_id\" text not null,\n       \"trusted_client_id\" text not null,\n       primary key (\"client_id\", \"trusted_client_id\")) ;\n",
+			},
+		},
 	},
 }

--- a/db/user.go
+++ b/db/user.go
@@ -248,7 +248,7 @@ func (r *userRepo) GetRemoteIdentities(tx repo.Transaction, userID string) ([]us
 		if err != sql.ErrNoRows {
 			return nil, err
 		}
-		return nil, err
+		return nil, nil
 	}
 	if len(rims) == 0 {
 		return nil, nil

--- a/functional/db_test.go
+++ b/functional/db_test.go
@@ -316,7 +316,7 @@ func TestDBClientRepoAuthenticate(t *testing.T) {
 	cli := client.Client{
 		Metadata: cm,
 	}
-	cc, err := m.New(cli)
+	cc, err := m.New(cli, nil)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/integration/admin_api_test.go
+++ b/integration/admin_api_test.go
@@ -382,10 +382,9 @@ func TestCreateClient(t *testing.T) {
 		return u
 	}
 
-	addIDAndSecret := func(cliNum int, hostport string, cli adminschema.Client) *adminschema.Client {
-		cli.Id = fmt.Sprintf("client_%v.example.com", hostport)
-		cli.Secret = base64.URLEncoding.EncodeToString([]byte(
-			fmt.Sprintf("client_%d", cliNum)))
+	addIDAndSecret := func(cli adminschema.Client) *adminschema.Client {
+		cli.Id = "client_auth.example.com"
+		cli.Secret = base64.URLEncoding.EncodeToString([]byte("client_0"))
 		return &cli
 	}
 
@@ -448,7 +447,7 @@ func TestCreateClient(t *testing.T) {
 				Client: &adminClientGood,
 			},
 			want: adminschema.ClientCreateResponse{
-				Client: addIDAndSecret(2, "auth", adminClientGood),
+				Client: addIDAndSecret(adminClientGood),
 			},
 			wantClient: clientGood,
 		},
@@ -457,7 +456,7 @@ func TestCreateClient(t *testing.T) {
 				Client: &adminAdminClient,
 			},
 			want: adminschema.ClientCreateResponse{
-				Client: addIDAndSecret(2, "auth", adminAdminClient),
+				Client: addIDAndSecret(adminAdminClient),
 			},
 			wantClient: clientGoodAdmin,
 		},
@@ -466,7 +465,7 @@ func TestCreateClient(t *testing.T) {
 				Client: &adminMultiRedirect,
 			},
 			want: adminschema.ClientCreateResponse{
-				Client: addIDAndSecret(2, "auth", adminMultiRedirect),
+				Client: addIDAndSecret(adminMultiRedirect),
 			},
 			wantClient: clientMultiRedirect,
 		},
@@ -475,7 +474,7 @@ func TestCreateClient(t *testing.T) {
 				Client: &adminClientWithPeers,
 			},
 			want: adminschema.ClientCreateResponse{
-				Client: addIDAndSecret(2, "auth", adminClientWithPeers),
+				Client: addIDAndSecret(adminClientWithPeers),
 			},
 			wantClient:       clientGood,
 			wantTrustedPeers: []string{"test_client_0"},

--- a/integration/user_api_test.go
+++ b/integration/user_api_test.go
@@ -618,7 +618,7 @@ func TestRefreshTokenEndpoints(t *testing.T) {
 			t.Errorf("case %d: expected client ids did not match actual: %s", i, diff)
 		}
 		for _, clientID := range ids {
-			if err := f.client.Clients.Revoke(tt.userID, clientID).Do(); err != nil {
+			if err := f.client.RefreshClient.Revoke(tt.userID, clientID).Do(); err != nil {
 				t.Errorf("case %d: failed to revoke client: %v", i, err)
 			}
 		}

--- a/schema/adminschema/README.md
+++ b/schema/adminschema/README.md
@@ -34,7 +34,10 @@ __Version:__ v1
     redirectURIs: [
         string
     ],
-    secret: string // The client secret. Ignored in client create requests.
+    secret: string // The client secret. Ignored in client create requests.,
+    trustedPeers: [
+        string
+    ]
 }
 ```
 

--- a/schema/adminschema/v1-gen.go
+++ b/schema/adminschema/v1-gen.go
@@ -148,6 +148,10 @@ type Client struct {
 
 	// Secret: The client secret. Ignored in client create requests.
 	Secret string `json:"secret,omitempty"`
+
+	// TrustedPeers: Array of ClientIDs of clients that are allowed to mint
+	// ID tokens for the client being created.
+	TrustedPeers []string `json:"trustedPeers,omitempty"`
 }
 
 type ClientCreateRequest struct {

--- a/schema/adminschema/v1-json.go
+++ b/schema/adminschema/v1-json.go
@@ -84,6 +84,13 @@ const DiscoveryJSON = `{
         "clientURI": {
           "type": "string",
           "description": "OPTIONAL. URL of the home page of the Client. The value of this field MUST point to a valid Web page. If present, the server SHOULD display this URL to the End-User in a followable fashion. If desired, representation of this Claim in different languages and scripts is represented as described in Section 2.1 ( Metadata Languages and Scripts ) ."
+        },
+        "trustedPeers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of ClientIDs of clients that are allowed to mint ID tokens for the client being created."
         }
       }
     },
@@ -228,4 +235,5 @@ const DiscoveryJSON = `{
     }
   }
 }
+
 `

--- a/schema/adminschema/v1.json
+++ b/schema/adminschema/v1.json
@@ -78,6 +78,13 @@
         "clientURI": {
           "type": "string",
           "description": "OPTIONAL. URL of the home page of the Client. The value of this field MUST point to a valid Web page. If present, the server SHOULD display this URL to the End-User in a followable fashion. If desired, representation of this Claim in different languages and scripts is represented as described in Section 2.1 ( Metadata Languages and Scripts ) ."
+        },
+        "trustedPeers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of ClientIDs of clients that are allowed to mint ID tokens for the client being created."
         }
       }
     },
@@ -222,3 +229,4 @@
     }
   }
 }
+

--- a/schema/workerschema/README.md
+++ b/schema/workerschema/README.md
@@ -232,8 +232,8 @@ A client with associated public metadata.
 
 > |Name|Located in|Description|Required|Type|
 |:-----|:-----|:-----|:-----|:-----|
-| userid | path |  | Yes | string | 
 | clientid | path |  | Yes | string | 
+| userid | path |  | Yes | string | 
 
 
 > __Responses__
@@ -310,8 +310,8 @@ A client with associated public metadata.
 
 > |Name|Located in|Description|Required|Type|
 |:-----|:-----|:-----|:-----|:-----|
-| maxResults | query |  | No | integer | 
 | nextPageToken | query |  | No | string | 
+| maxResults | query |  | No | integer | 
 
 
 > __Responses__

--- a/schema/workerschema/README.md
+++ b/schema/workerschema/README.md
@@ -199,7 +199,7 @@ A client with associated public metadata.
 
 > __Description__
 
-> List all clients that hold refresh tokens for the authenticated user.
+> List all clients that hold refresh tokens for the specified user.
 
 
 > __Parameters__
@@ -221,11 +221,11 @@ A client with associated public metadata.
 
 > __Summary__
 
-> Revoke Clients
+> Revoke RefreshClient
 
 > __Description__
 
-> Revoke all refresh tokens issues to the client for the authenticated user.
+> Revoke all refresh tokens issues to the client for the specified user.
 
 
 > __Parameters__

--- a/schema/workerschema/v1-gen.go
+++ b/schema/workerschema/v1-gen.go
@@ -334,82 +334,7 @@ func (c *ClientsListCall) Do() (*ClientPage, error) {
 
 }
 
-// method id "dex.Client.Revoke":
-
-type ClientsRevokeCall struct {
-	s        *Service
-	userid   string
-	clientid string
-	opt_     map[string]interface{}
-}
-
-// Revoke: Revoke all refresh tokens issues to the client for the
-// authenticated user.
-func (r *ClientsService) Revoke(userid string, clientid string) *ClientsRevokeCall {
-	c := &ClientsRevokeCall{s: r.s, opt_: make(map[string]interface{})}
-	c.userid = userid
-	c.clientid = clientid
-	return c
-}
-
-// Fields allows partial responses to be retrieved.
-// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
-// for more information.
-func (c *ClientsRevokeCall) Fields(s ...googleapi.Field) *ClientsRevokeCall {
-	c.opt_["fields"] = googleapi.CombineFields(s)
-	return c
-}
-
-func (c *ClientsRevokeCall) Do() error {
-	var body io.Reader = nil
-	params := make(url.Values)
-	params.Set("alt", "json")
-	if v, ok := c.opt_["fields"]; ok {
-		params.Set("fields", fmt.Sprintf("%v", v))
-	}
-	urls := googleapi.ResolveRelative(c.s.BasePath, "account/{userid}/refresh/{clientid}")
-	urls += "?" + params.Encode()
-	req, _ := http.NewRequest("DELETE", urls, body)
-	googleapi.Expand(req.URL, map[string]string{
-		"userid":   c.userid,
-		"clientid": c.clientid,
-	})
-	req.Header.Set("User-Agent", "google-api-go-client/0.5")
-	res, err := c.s.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer googleapi.CloseBody(res)
-	if err := googleapi.CheckResponse(res); err != nil {
-		return err
-	}
-	return nil
-	// {
-	//   "description": "Revoke all refresh tokens issues to the client for the authenticated user.",
-	//   "httpMethod": "DELETE",
-	//   "id": "dex.Client.Revoke",
-	//   "parameterOrder": [
-	//     "userid",
-	//     "clientid"
-	//   ],
-	//   "parameters": {
-	//     "clientid": {
-	//       "location": "path",
-	//       "required": true,
-	//       "type": "string"
-	//     },
-	//     "userid": {
-	//       "location": "path",
-	//       "required": true,
-	//       "type": "string"
-	//     }
-	//   },
-	//   "path": "account/{userid}/refresh/{clientid}"
-	// }
-
-}
-
-// method id "dex.Client.List":
+// method id "dex.RefreshClient.List":
 
 type RefreshClientListCall struct {
 	s      *Service
@@ -417,7 +342,7 @@ type RefreshClientListCall struct {
 	opt_   map[string]interface{}
 }
 
-// List: List all clients that hold refresh tokens for the authenticated
+// List: List all clients that hold refresh tokens for the specified
 // user.
 func (r *RefreshClientService) List(userid string) *RefreshClientListCall {
 	c := &RefreshClientListCall{s: r.s, opt_: make(map[string]interface{})}
@@ -461,9 +386,9 @@ func (c *RefreshClientListCall) Do() (*RefreshClientList, error) {
 	}
 	return ret, nil
 	// {
-	//   "description": "List all clients that hold refresh tokens for the authenticated user.",
+	//   "description": "List all clients that hold refresh tokens for the specified user.",
 	//   "httpMethod": "GET",
-	//   "id": "dex.Client.List",
+	//   "id": "dex.RefreshClient.List",
 	//   "parameterOrder": [
 	//     "userid"
 	//   ],
@@ -478,6 +403,81 @@ func (c *RefreshClientListCall) Do() (*RefreshClientList, error) {
 	//   "response": {
 	//     "$ref": "RefreshClientList"
 	//   }
+	// }
+
+}
+
+// method id "dex.RefreshClient.Revoke":
+
+type RefreshClientRevokeCall struct {
+	s        *Service
+	userid   string
+	clientid string
+	opt_     map[string]interface{}
+}
+
+// Revoke: Revoke all refresh tokens issues to the client for the
+// specified user.
+func (r *RefreshClientService) Revoke(userid string, clientid string) *RefreshClientRevokeCall {
+	c := &RefreshClientRevokeCall{s: r.s, opt_: make(map[string]interface{})}
+	c.userid = userid
+	c.clientid = clientid
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *RefreshClientRevokeCall) Fields(s ...googleapi.Field) *RefreshClientRevokeCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *RefreshClientRevokeCall) Do() error {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "account/{userid}/refresh/{clientid}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("DELETE", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"userid":   c.userid,
+		"clientid": c.clientid,
+	})
+	req.Header.Set("User-Agent", "google-api-go-client/0.5")
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return err
+	}
+	return nil
+	// {
+	//   "description": "Revoke all refresh tokens issues to the client for the specified user.",
+	//   "httpMethod": "DELETE",
+	//   "id": "dex.RefreshClient.Revoke",
+	//   "parameterOrder": [
+	//     "userid",
+	//     "clientid"
+	//   ],
+	//   "parameters": {
+	//     "clientid": {
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "userid": {
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "account/{userid}/refresh/{clientid}"
 	// }
 
 }

--- a/schema/workerschema/v1-json.go
+++ b/schema/workerschema/v1-json.go
@@ -272,28 +272,6 @@ const DiscoveryJSON = `{
           "response": {
             "$ref": "ClientWithSecret"
           }
-        },
-        "Revoke": {
-          "id": "dex.Client.Revoke",
-          "description": "Revoke all refresh tokens issues to the client for the authenticated user.",
-          "httpMethod": "DELETE",
-          "path": "account/{userid}/refresh/{clientid}",
-          "parameterOrder": [
-            "userid",
-            "clientid"
-          ],
-          "parameters": {
-            "clientid": {
-              "type": "string",
-              "required": true,
-              "location": "path"
-            },
-            "userid": {
-              "type": "string",
-              "required": true,
-              "location": "path"
-            }
-          }
         }
       }
     },
@@ -398,8 +376,8 @@ const DiscoveryJSON = `{
     "RefreshClient": {
       "methods": {
         "List": {
-          "id": "dex.Client.List",
-          "description": "List all clients that hold refresh tokens for the authenticated user.",
+          "id": "dex.RefreshClient.List",
+          "description": "List all clients that hold refresh tokens for the specified user.",
           "httpMethod": "GET",
           "path": "account/{userid}/refresh",
           "parameters": {
@@ -414,6 +392,28 @@ const DiscoveryJSON = `{
           ],
           "response": {
             "$ref": "RefreshClientList"
+          }
+        },
+        "Revoke": {
+          "id": "dex.RefreshClient.Revoke",
+          "description": "Revoke all refresh tokens issues to the client for the specified user.",
+          "httpMethod": "DELETE",
+          "path": "account/{userid}/refresh/{clientid}",
+          "parameterOrder": [
+            "userid",
+            "clientid"
+          ],
+          "parameters": {
+            "clientid": {
+              "type": "string",
+              "required": true,
+              "location": "path"
+            },
+            "userid": {
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
           }
         }
       }

--- a/schema/workerschema/v1.json
+++ b/schema/workerschema/v1.json
@@ -266,28 +266,6 @@
           "response": {
             "$ref": "ClientWithSecret"
           }
-        },
-        "Revoke": {
-          "id": "dex.Client.Revoke",
-          "description": "Revoke all refresh tokens issues to the client for the authenticated user.",
-          "httpMethod": "DELETE",
-          "path": "account/{userid}/refresh/{clientid}",
-          "parameterOrder": [
-            "userid",
-            "clientid"
-          ],
-          "parameters": {
-            "clientid": {
-              "type": "string",
-              "required": true,
-              "location": "path"
-            },
-            "userid": {
-              "type": "string",
-              "required": true,
-              "location": "path"
-            }
-          }
         }
       }
     },
@@ -392,8 +370,8 @@
     "RefreshClient": {
       "methods": {
         "List": {
-          "id": "dex.Client.List",
-          "description": "List all clients that hold refresh tokens for the authenticated user.",
+          "id": "dex.RefreshClient.List",
+          "description": "List all clients that hold refresh tokens for the specified user.",
           "httpMethod": "GET",
           "path": "account/{userid}/refresh",
           "parameters": {
@@ -408,6 +386,28 @@
           ],
           "response": {
             "$ref": "RefreshClientList"
+          }
+        },
+        "Revoke": {
+          "id": "dex.RefreshClient.Revoke",
+          "description": "Revoke all refresh tokens issues to the client for the specified user.",
+          "httpMethod": "DELETE",
+          "path": "account/{userid}/refresh/{clientid}",
+          "parameterOrder": [
+            "userid",
+            "clientid"
+          ],
+          "parameters": {
+            "clientid": {
+              "type": "string",
+              "required": true,
+              "location": "path"
+            },
+            "userid": {
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
           }
         }
       }

--- a/scope/scope.go
+++ b/scope/scope.go
@@ -1,0 +1,34 @@
+package scope
+
+import "strings"
+
+const (
+	// Scope prefix which indicates initiation of a cross-client authentication flow.
+	// See https://developers.google.com/identity/protocols/CrossClientAuth
+	ScopeGoogleCrossClient = "audience:server:client_id:"
+)
+
+type Scopes []string
+
+func (s Scopes) OfflineAccess() bool {
+	return s.HasScope("offline_access")
+}
+
+func (s Scopes) HasScope(scope string) bool {
+	for _, curScope := range s {
+		if curScope == scope {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Scopes) CrossClientIDs() []string {
+	clients := []string{}
+	for _, scope := range s {
+		if strings.HasPrefix(scope, ScopeGoogleCrossClient) {
+			clients = append(clients, scope[len(ScopeGoogleCrossClient):])
+		}
+	}
+	return clients
+}

--- a/server/auth_middleware_test.go
+++ b/server/auth_middleware_test.go
@@ -37,7 +37,7 @@ func TestClientToken(t *testing.T) {
 	cli := client.Client{
 		Metadata: clientMetadata,
 	}
-	creds, err := clientManager.New(cli)
+	creds, err := clientManager.New(cli, nil)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/server/client_registration.go
+++ b/server/client_registration.go
@@ -42,7 +42,7 @@ func (s *Server) handleClientRegistrationRequest(r *http.Request) (*oidc.ClientR
 	cli := client.Client{
 		Metadata: clientMetadata,
 	}
-	creds, err := s.ClientManager.New(cli)
+	creds, err := s.ClientManager.New(cli, nil)
 	if err != nil {
 		log.Errorf("Failed to create new client identity: %v", err)
 		return nil, newAPIError(oauth2.ErrorServerError, "unable to save client metadata")

--- a/server/client_resource.go
+++ b/server/client_resource.go
@@ -87,7 +87,7 @@ func (c *clientResource) create(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusBadRequest, newAPIError(errorInvalidClientMetadata, err.Error()))
 		return
 	}
-	creds, err := c.manager.New(ci)
+	creds, err := c.manager.New(ci, nil)
 
 	if err != nil {
 		log.Errorf("Failed creating client: %v", err)

--- a/server/cross_client_test.go
+++ b/server/cross_client_test.go
@@ -1,0 +1,202 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/coreos/go-oidc/oidc"
+
+	"github.com/coreos/dex/client"
+	"github.com/coreos/dex/connector"
+)
+
+func makeCrossClientTestFixtures() (*testFixtures, error) {
+	f, err := makeTestFixtures()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't make test fixtures: %v", err)
+	}
+
+	creds := map[string]oidc.ClientCredentials{}
+	for _, cliData := range []struct {
+		id         string
+		authorized []string
+	}{
+		{
+			id: "client_a",
+		}, {
+			id:         "client_b",
+			authorized: []string{"client_a"},
+		}, {
+			id:         "client_c",
+			authorized: []string{"client_a", "client_b"},
+		},
+	} {
+		u := url.URL{
+			Scheme: "https://",
+			Path:   cliData.id,
+			Host:   "auth.example.com",
+		}
+		cliCreds, err := f.clientRepo.New(client.Client{
+			Credentials: oidc.ClientCredentials{
+				ID: cliData.id,
+			},
+			Metadata: oidc.ClientMetadata{
+				RedirectURIs: []url.URL{u},
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("Unexpected error creating clients: %v", err)
+		}
+		creds[cliData.id] = *cliCreds
+		err = f.clientRepo.SetTrustedPeers(cliData.id, cliData.authorized)
+		if err != nil {
+			return nil, fmt.Errorf("Unexpected error setting cross-client authorizers: %v", err)
+		}
+	}
+	return f, nil
+}
+
+func TestServerCrossClientAuthAllowed(t *testing.T) {
+	f, err := makeCrossClientTestFixtures()
+	if err != nil {
+		t.Fatalf("couldn't make test fixtures: %v", err)
+	}
+
+	tests := []struct {
+		reqClient      string
+		authClient     string
+		wantAuthorized bool
+		wantErr        bool
+	}{
+		{
+			reqClient:      "client_b",
+			authClient:     "client_a",
+			wantAuthorized: false,
+			wantErr:        false,
+		},
+		{
+			reqClient:      "client_a",
+			authClient:     "client_b",
+			wantAuthorized: true,
+			wantErr:        false,
+		},
+		{
+			reqClient:      "client_a",
+			authClient:     "client_c",
+			wantAuthorized: true,
+			wantErr:        false,
+		},
+		{
+			reqClient:      "client_c",
+			authClient:     "client_b",
+			wantAuthorized: false,
+			wantErr:        false,
+		},
+		{
+			reqClient:  "client_c",
+			authClient: "nope",
+			wantErr:    false,
+		},
+	}
+	for i, tt := range tests {
+		got, err := f.srv.CrossClientAuthAllowed(tt.reqClient, tt.authClient)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("case %d: want non-nil err", i)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("case %d: unexpected err %v: ", i, err)
+		}
+
+		if got != tt.wantAuthorized {
+			t.Errorf("case %d: want=%v, got=%v", i, tt.wantAuthorized, got)
+		}
+	}
+}
+
+func TestHandleAuthCrossClient(t *testing.T) {
+	f, err := makeCrossClientTestFixtures()
+	if err != nil {
+		t.Fatalf("couldn't make test fixtures: %v", err)
+	}
+
+	tests := []struct {
+		scopes   []string
+		clientID string
+		wantCode int
+	}{
+		{
+			scopes:   []string{ScopeGoogleCrossClient + "client_a"},
+			clientID: "client_b",
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			scopes:   []string{ScopeGoogleCrossClient + "client_b"},
+			clientID: "client_a",
+			wantCode: http.StatusFound,
+		},
+		{
+			scopes:   []string{ScopeGoogleCrossClient + "client_b"},
+			clientID: "client_a",
+			wantCode: http.StatusFound,
+		},
+		{
+			scopes:   []string{ScopeGoogleCrossClient + "client_c"},
+			clientID: "client_a",
+			wantCode: http.StatusFound,
+		},
+		{
+			// Two clients that client_a is authorized to mint tokens for.
+			scopes: []string{
+				ScopeGoogleCrossClient + "client_c",
+				ScopeGoogleCrossClient + "client_b",
+			},
+			clientID: "client_a",
+			wantCode: http.StatusFound,
+		},
+		{
+			// Two clients that client_a is authorized to mint tokens for.
+			scopes: []string{
+				ScopeGoogleCrossClient + "client_c",
+				ScopeGoogleCrossClient + "client_a",
+			},
+			clientID: "client_b",
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	idpcs := []connector.Connector{
+		&fakeConnector{loginURL: "http://fake.example.com"},
+	}
+
+	for i, tt := range tests {
+		hdlr := handleAuthFunc(f.srv, idpcs, nil, true)
+		w := httptest.NewRecorder()
+
+		query := url.Values{
+			"response_type": []string{"code"},
+			"client_id":     []string{tt.clientID},
+			"connector_id":  []string{"fake"},
+			"scope":         []string{strings.Join(append([]string{"openid"}, tt.scopes...), " ")},
+		}
+		u := fmt.Sprintf("http://server.example.com?%s", query.Encode())
+		req, err := http.NewRequest("GET", u, nil)
+		if err != nil {
+			t.Errorf("case %d: unable to form HTTP request: %v", i, err)
+			continue
+		}
+
+		hdlr.ServeHTTP(w, req)
+		if tt.wantCode != w.Code {
+			t.Errorf("case %d: HTTP code mismatch: want=%d got=%d", i, tt.wantCode, w.Code)
+			continue
+		}
+	}
+
+}

--- a/server/cross_client_test.go
+++ b/server/cross_client_test.go
@@ -1,17 +1,22 @@
 package server
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/coreos/go-oidc/oidc"
+	"github.com/kylelemons/godebug/pretty"
 
 	"github.com/coreos/dex/client"
+	clientmanager "github.com/coreos/dex/client/manager"
 	"github.com/coreos/dex/connector"
+	"github.com/coreos/dex/scope"
 )
 
 func makeCrossClientTestFixtures() (*testFixtures, error) {
@@ -20,7 +25,6 @@ func makeCrossClientTestFixtures() (*testFixtures, error) {
 		return nil, fmt.Errorf("couldn't make test fixtures: %v", err)
 	}
 
-	creds := map[string]oidc.ClientCredentials{}
 	for _, cliData := range []struct {
 		id         string
 		authorized []string
@@ -38,24 +42,22 @@ func makeCrossClientTestFixtures() (*testFixtures, error) {
 		u := url.URL{
 			Scheme: "https://",
 			Path:   cliData.id,
-			Host:   "auth.example.com",
+			Host:   cliData.id,
 		}
-		cliCreds, err := f.clientRepo.New(client.Client{
+		cliCreds, err := f.clientManager.New(client.Client{
 			Credentials: oidc.ClientCredentials{
 				ID: cliData.id,
 			},
 			Metadata: oidc.ClientMetadata{
 				RedirectURIs: []url.URL{u},
 			},
+		}, &clientmanager.ClientOptions{
+			TrustedPeers: cliData.authorized,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("Unexpected error creating clients: %v", err)
 		}
-		creds[cliData.id] = *cliCreds
-		err = f.clientRepo.SetTrustedPeers(cliData.id, cliData.authorized)
-		if err != nil {
-			return nil, fmt.Errorf("Unexpected error setting cross-client authorizers: %v", err)
-		}
+		f.clientCreds[cliData.id] = *cliCreds
 	}
 	return f, nil
 }
@@ -132,30 +134,30 @@ func TestHandleAuthCrossClient(t *testing.T) {
 		wantCode int
 	}{
 		{
-			scopes:   []string{ScopeGoogleCrossClient + "client_a"},
+			scopes:   []string{scope.ScopeGoogleCrossClient + "client_a"},
 			clientID: "client_b",
 			wantCode: http.StatusBadRequest,
 		},
 		{
-			scopes:   []string{ScopeGoogleCrossClient + "client_b"},
+			scopes:   []string{scope.ScopeGoogleCrossClient + "client_b"},
 			clientID: "client_a",
 			wantCode: http.StatusFound,
 		},
 		{
-			scopes:   []string{ScopeGoogleCrossClient + "client_b"},
+			scopes:   []string{scope.ScopeGoogleCrossClient + "client_b"},
 			clientID: "client_a",
 			wantCode: http.StatusFound,
 		},
 		{
-			scopes:   []string{ScopeGoogleCrossClient + "client_c"},
+			scopes:   []string{scope.ScopeGoogleCrossClient + "client_c"},
 			clientID: "client_a",
 			wantCode: http.StatusFound,
 		},
 		{
 			// Two clients that client_a is authorized to mint tokens for.
 			scopes: []string{
-				ScopeGoogleCrossClient + "client_c",
-				ScopeGoogleCrossClient + "client_b",
+				scope.ScopeGoogleCrossClient + "client_c",
+				scope.ScopeGoogleCrossClient + "client_b",
 			},
 			clientID: "client_a",
 			wantCode: http.StatusFound,
@@ -163,8 +165,8 @@ func TestHandleAuthCrossClient(t *testing.T) {
 		{
 			// Two clients that client_a is authorized to mint tokens for.
 			scopes: []string{
-				ScopeGoogleCrossClient + "client_c",
-				ScopeGoogleCrossClient + "client_a",
+				scope.ScopeGoogleCrossClient + "client_c",
+				scope.ScopeGoogleCrossClient + "client_a",
 			},
 			clientID: "client_b",
 			wantCode: http.StatusBadRequest,
@@ -199,4 +201,130 @@ func TestHandleAuthCrossClient(t *testing.T) {
 		}
 	}
 
+}
+
+func TestServerCodeTokenCrossClient(t *testing.T) {
+	f, err := makeCrossClientTestFixtures()
+	if err != nil {
+		t.Fatalf("Error creating test fixtures: %v", err)
+	}
+	sm := f.sessionManager
+
+	tests := []struct {
+		clientID     string
+		offline      bool
+		refreshToken string
+		crossClients []string
+
+		wantErr bool
+		wantAUD []string
+		wantAZP string
+	}{
+		// First test the non-cross-client cases, make sure they're undisturbed:
+		{
+			// No 'offline_access' in scope, should get empty refresh token.
+			clientID:     testClientID,
+			refreshToken: "",
+
+			wantAUD: []string{testClientID},
+		},
+		{
+			// Have 'offline_access' in scope, should get non-empty refresh token.
+			clientID:     testClientID,
+			offline:      true,
+			refreshToken: fmt.Sprintf("1/%s", base64.URLEncoding.EncodeToString([]byte("refresh-1"))),
+
+			wantAUD: []string{testClientID},
+		},
+		// Now test cross-client cases:
+		{
+			clientID:     "client_a",
+			crossClients: []string{"client_b"},
+
+			wantAUD: []string{"client_b"},
+			wantAZP: "client_a",
+		},
+		{
+			clientID:     "client_a",
+			crossClients: []string{"client_b", "client_a"},
+
+			wantAUD: []string{"client_a", "client_b"},
+			wantAZP: "client_a",
+		},
+	}
+
+	for i, tt := range tests {
+		scopes := []string{"openid"}
+		if tt.offline {
+			scopes = append(scopes, "offline_access")
+		}
+		for _, client := range tt.crossClients {
+			scopes = append(scopes, scope.ScopeGoogleCrossClient+client)
+		}
+
+		sessionID, err := sm.NewSession("bogus_idpc", tt.clientID, "bogus", url.URL{}, "", false, scopes)
+		if err != nil {
+			t.Fatalf("case %d: unexpected error: %v", i, err)
+		}
+		_, err = sm.AttachRemoteIdentity(sessionID, oidc.Identity{})
+		if err != nil {
+			t.Fatalf("case %d: unexpected error: %v", i, err)
+		}
+
+		_, err = sm.AttachUser(sessionID, "ID-1")
+		if err != nil {
+			t.Fatalf("case %d: unexpected error: %v", i, err)
+		}
+
+		key, err := sm.NewSessionKey(sessionID)
+		if err != nil {
+			t.Fatalf("case %d: unexpected error: %v", i, err)
+		}
+
+		jwt, token, err := f.srv.CodeToken(f.clientCreds[tt.clientID], key)
+		if err != nil {
+			t.Fatalf("case %d: unexpected error: %v", i, err)
+		}
+		if jwt == nil {
+			t.Fatalf("case %d: expect non-nil jwt", i)
+		}
+		if token != tt.refreshToken {
+			t.Errorf("case %d: expect refresh token %q, got %q", i, tt.refreshToken, token)
+		}
+
+		claims, err := jwt.Claims()
+		if err != nil {
+			t.Fatalf("case %d: unexpected error getting claims: %v", i, err)
+		}
+
+		var gotAUD []string
+		if len(tt.wantAUD) < 2 {
+			aud, _, err := claims.StringClaim("aud")
+			if err != nil {
+				t.Fatalf("case %d: unexpected error getting 'aud': %q: raw: %v", i, err, claims["aud"])
+			}
+			gotAUD = []string{aud}
+		} else {
+			gotAUD, _, err = claims.StringsClaim("aud")
+			if err != nil {
+				t.Fatalf("case %d: unexpected error getting 'aud': %v", i, err)
+			}
+		}
+
+		sort.Strings(gotAUD)
+		if diff := pretty.Compare(tt.wantAUD, gotAUD); diff != "" {
+			t.Fatalf("case %d: pretty.Compare(tt.wantAUD, gotAUD): %v", i, diff)
+		}
+
+		gotAZP, _, err := claims.StringClaim("azp")
+		if err != nil {
+			if err != nil {
+				t.Fatalf("case %d: unexpected error getting 'aud': %v", i, err)
+			}
+		}
+
+		if gotAZP != tt.wantAZP {
+			t.Errorf("case %d: wantAZP=%v, gotAZP=%v", i, tt.wantAZP, gotAZP)
+		}
+	}
 }

--- a/server/http.go
+++ b/server/http.go
@@ -264,7 +264,7 @@ func renderLoginPage(w http.ResponseWriter, r *http.Request, srv OIDCServer, idp
 	execTemplate(w, tpl, td)
 }
 
-func handleAuthFunc(srv DexServer, idpcs []connector.Connector, tpl *template.Template, registrationEnabled bool) http.HandlerFunc {
+func handleAuthFunc(srv OIDCServer, idpcs []connector.Connector, tpl *template.Template, registrationEnabled bool) http.HandlerFunc {
 	idx := makeConnectorMap(idpcs)
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
@@ -390,7 +390,7 @@ func handleAuthFunc(srv DexServer, idpcs []connector.Connector, tpl *template.Te
 	}
 }
 
-func validateScopes(srv DexServer, clientID string, scopes []string) error {
+func validateScopes(srv OIDCServer, clientID string, scopes []string) error {
 	foundOpenIDScope := false
 	for i, curScope := range scopes {
 		if i > 0 && curScope == scopes[i-1] {

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/coreos/dex/client"
 	"github.com/coreos/dex/connector"
+	"github.com/coreos/dex/scope"
 	"github.com/coreos/go-oidc/jose"
 	"github.com/coreos/go-oidc/oauth2"
 	"github.com/coreos/go-oidc/oidc"
@@ -346,21 +347,21 @@ func TestValidateScopes(t *testing.T) {
 		{
 			// ERR: invalid cross client auth
 			clientID: "XXX",
-			scopes:   []string{"openid", ScopeGoogleCrossClient + "client_a"},
+			scopes:   []string{"openid", scope.ScopeGoogleCrossClient + "client_a"},
 			wantErr:  true,
 		},
 		{
 			// OK: valid cross client auth (though perverse - a client
 			// requesting cross-client auth for itself)
 			clientID: "client_a",
-			scopes:   []string{"openid", ScopeGoogleCrossClient + "client_a"},
+			scopes:   []string{"openid", scope.ScopeGoogleCrossClient + "client_a"},
 			wantErr:  false,
 		},
 		{
 
 			// OK: valid cross client auth
 			clientID: "client_a",
-			scopes:   []string{"openid", ScopeGoogleCrossClient + "client_b"},
+			scopes:   []string{"openid", scope.ScopeGoogleCrossClient + "client_b"},
 			wantErr:  false,
 		},
 		{
@@ -368,8 +369,8 @@ func TestValidateScopes(t *testing.T) {
 			// ERR: valid cross client auth...but duplicated scope.
 			clientID: "client_a",
 			scopes: []string{"openid",
-				ScopeGoogleCrossClient + "client_b",
-				ScopeGoogleCrossClient + "client_b",
+				scope.ScopeGoogleCrossClient + "client_b",
+				scope.ScopeGoogleCrossClient + "client_b",
 			},
 			wantErr: true,
 		},
@@ -378,9 +379,9 @@ func TestValidateScopes(t *testing.T) {
 			clientID: "client_a",
 			scopes: []string{
 				"openid",
-				ScopeGoogleCrossClient + "client_a",
-				ScopeGoogleCrossClient + "client_b",
-				ScopeGoogleCrossClient + "client_c",
+				scope.ScopeGoogleCrossClient + "client_a",
+				scope.ScopeGoogleCrossClient + "client_b",
+				scope.ScopeGoogleCrossClient + "client_c",
 			},
 			wantErr: false,
 		},
@@ -388,9 +389,9 @@ func TestValidateScopes(t *testing.T) {
 			// ERR: valid cross client auth with >1 clients including itself...but no openid!
 			clientID: "client_a",
 			scopes: []string{
-				ScopeGoogleCrossClient + "client_a",
-				ScopeGoogleCrossClient + "client_b",
-				ScopeGoogleCrossClient + "client_c",
+				scope.ScopeGoogleCrossClient + "client_a",
+				scope.ScopeGoogleCrossClient + "client_b",
+				scope.ScopeGoogleCrossClient + "client_c",
 			},
 			wantErr: true,
 		},

--- a/server/server.go
+++ b/server/server.go
@@ -56,13 +56,7 @@ type OIDCServer interface {
 	RefreshToken(creds oidc.ClientCredentials, token string) (*jose.JWT, error)
 
 	KillSession(string) error
-}
 
-// DexServer is an OIDCServer that also has dex-specific features.
-type DexServer interface {
-	OIDCServer
-
-	// CrossClientAuthAllowed
 	CrossClientAuthAllowed(requestingClientID, authorizingClientID string) (bool, error)
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/coreos/go-oidc/jose"
 	"github.com/coreos/go-oidc/oidc"
+
+	"github.com/coreos/dex/scope"
 )
 
 const (
@@ -46,11 +48,13 @@ type Session struct {
 	// Regsiter indicates that this session is a registration flow.
 	Register bool
 
-	// Nonce is optionally provided in the initial authorization request, and propogated in such cases to the generated claims.
+	// Nonce is optionally provided in the initial authorization request, and
+	// propogated in such cases to the generated claims.
 	Nonce string
 
-	// Scope is the 'scope' field in the authentication request. Example scopes are 'openid', 'email', 'offline', etc.
-	Scope []string
+	// Scope is the 'scope' field in the authentication request. Example scopes
+	// are 'openid', 'email', 'offline', etc.
+	Scope scope.Scopes
 }
 
 // Claims returns a new set of Claims for the current session.


### PR DESCRIPTION
work for #371 

With this commit dex will perform cross-client auth for trusted peers. 

Refresh tokens are not handled yet, nor is updating trusted peers through worker api.
