### PR TITLE
use go 1.6.2 for docker go build

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -1,5 +1,0 @@
-FROM golang:1.6
-
-RUN go get golang.org/x/tools/cmd/cover
-RUN go get golang.org/x/tools/cmd/vet
-RUN go get github.com/tools/godep

--- a/go-docker
+++ b/go-docker
@@ -23,4 +23,4 @@ for VAR in ${DOCKER_LINKS//,/ }; do
 done
 
 echo "running with docker, might take a while to pull the image..."
-docker run $LINKS_STR $ENV_STR --rm  -v `pwd`:/go/src/$REPO -w /go/src/$REPO quay.io/coreos/dex-builder:1.4 $@
+docker run $LINKS_STR $ENV_STR --rm -v `pwd`:/go/src/$REPO -w /go/src/$REPO -t golang:1.6.2 $@


### PR DESCRIPTION
I switched to the official golang image. Not sure if there was a reason to use the dex-builder image?

supersedes #406
fixes #404