### PR TITLE
Various client api tweaks

### DIFF
--- a/client/manager/manager.go
+++ b/client/manager/manager.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"encoding/base64"
-	"fmt"
 
 	"errors"
 
@@ -62,35 +61,6 @@ func NewClientManager(clientRepo client.ClientRepo, txnFactory repo.TransactionF
 		secretGenerator:   options.SecretGenerator,
 		clientIDGenerator: options.ClientIDGenerator,
 	}
-}
-
-func NewClientManagerFromClients(clientRepo client.ClientRepo, txnFactory repo.TransactionFactory, clients []client.Client, options ManagerOptions) (*ClientManager, error) {
-	clientManager := NewClientManager(clientRepo, txnFactory, options)
-	tx, err := clientManager.begin()
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
-	for _, c := range clients {
-		if c.Credentials.Secret == "" {
-			return nil, fmt.Errorf("client %q has no secret", c.Credentials.ID)
-		}
-
-		err := clientManager.addClientCredentials(&c)
-		if err != nil {
-			return nil, err
-		}
-
-		_, err = clientRepo.New(tx, c)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-	return clientManager, nil
 }
 
 func (m *ClientManager) New(cli client.Client) (*oidc.ClientCredentials, error) {

--- a/client/manager/manager_test.go
+++ b/client/manager/manager_test.go
@@ -44,11 +44,14 @@ func makeTestFixtures() *testFixtures {
 	secGen := func() ([]byte, error) {
 		return []byte("secret"), nil
 	}
-	f.clientRepo = db.NewClientRepo(dbMap)
-	clientManager, err := NewClientManagerFromClients(f.clientRepo, db.TransactionFactory(dbMap), clients, ManagerOptions{ClientIDGenerator: clientIDGenerator, SecretGenerator: secGen})
+
+	var err error
+	f.clientRepo, err = db.NewClientRepoFromClients(dbMap, clients)
 	if err != nil {
 		panic("Failed to create client manager: " + err.Error())
 	}
+
+	clientManager := NewClientManager(f.clientRepo, db.TransactionFactory(dbMap), ManagerOptions{ClientIDGenerator: clientIDGenerator, SecretGenerator: secGen})
 	f.mgr = clientManager
 	return f
 }

--- a/db/client.go
+++ b/db/client.go
@@ -199,6 +199,18 @@ func (r *clientRepo) All(tx repo.Transaction) ([]client.Client, error) {
 	return cs, nil
 }
 
+func NewClientRepoFromClients(dbm *gorp.DbMap, cs []client.Client) (client.ClientRepo, error) {
+	repo := NewClientRepo(dbm).(*clientRepo)
+	for _, c := range cs {
+		cm, err := newClientModel(c)
+		if err != nil {
+			return nil, err
+		}
+		err = repo.executor(nil).Insert(cm)
+	}
+	return repo, nil
+}
+
 func (r *clientRepo) get(tx repo.Transaction, clientID string) (client.Client, error) {
 	cm, err := r.getModel(tx, clientID)
 	if err != nil {

--- a/functional/config/config_sample_test.go
+++ b/functional/config/config_sample_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/coreos/dex/client"
+	"github.com/coreos/dex/client/manager"
+	"github.com/coreos/dex/db"
+)
+
+const (
+	clientsFile = "../../static/fixtures/clients.json.sample"
+)
+
+// TestClientSample makes sure that the clients.json.sample file is valid and can be loaded properly.
+func TestClientSample(t *testing.T) {
+	f, err := os.Open(clientsFile)
+	if err != nil {
+		t.Fatalf("could not open file %q: %v", clientsFile, err)
+	}
+	defer f.Close()
+
+	clients, err := client.ClientsFromReader(f)
+	if err != nil {
+		t.Fatalf("Error loading Clients: %v", err)
+	}
+
+	memDB := db.NewMemDB()
+	repo := db.NewClientRepo(memDB)
+	for _, c := range clients {
+		repo.New(nil, c)
+	}
+	mgr := manager.NewClientManager(repo, db.TransactionFactory(memDB), manager.ManagerOptions{})
+
+	for i, c := range clients {
+		ok, err := mgr.Authenticate(c.Credentials)
+		if !ok {
+			t.Errorf("case %d: couldn't authenticate", i)
+		}
+		if err != nil {
+			t.Errorf("case %d: error authenticating: %v", i, err)
+		}
+	}
+
+}

--- a/functional/repo/refresh_repo_test.go
+++ b/functional/repo/refresh_repo_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 
 	"github.com/coreos/dex/client"
-	"github.com/coreos/dex/client/manager"
 	"github.com/coreos/dex/db"
 	"github.com/coreos/dex/refresh"
 	"github.com/coreos/dex/user"
@@ -28,9 +27,7 @@ func newRefreshRepo(t *testing.T, users []user.UserWithRemoteIdentities, clients
 	if _, err := db.NewUserRepoFromUsers(dbMap, users); err != nil {
 		t.Fatalf("Unable to add users: %v", err)
 	}
-	if _, err := manager.NewClientManagerFromClients(db.NewClientRepo(dbMap), db.TransactionFactory(dbMap), clients, manager.ManagerOptions{}); err != nil {
-		t.Fatalf("Unable to add clients: %v", err)
-	}
+
 	return db.NewRefreshTokenRepo(dbMap)
 }
 

--- a/integration/user_api_test.go
+++ b/integration/user_api_test.go
@@ -18,7 +18,6 @@ import (
 	"google.golang.org/api/googleapi"
 
 	"github.com/coreos/dex/client"
-	"github.com/coreos/dex/client/manager"
 	"github.com/coreos/dex/db"
 	schema "github.com/coreos/dex/schema/workerschema"
 	"github.com/coreos/dex/server"
@@ -126,14 +125,8 @@ func makeUserAPITestFixtures() *userAPITestFixtures {
 			},
 		},
 	}
-	clientIDGenerator := func(hostport string) (string, error) {
-		return hostport, nil
-	}
-	secGen := func() ([]byte, error) {
-		return []byte(testClientSecret), nil
-	}
-	clientRepo := db.NewClientRepo(dbMap)
-	clientManager, err := manager.NewClientManagerFromClients(clientRepo, db.TransactionFactory(dbMap), clients, manager.ManagerOptions{ClientIDGenerator: clientIDGenerator, SecretGenerator: secGen})
+
+	_, clientManager, err := makeClientRepoAndManager(dbMap, clients)
 	if err != nil {
 		panic("Failed to create client identity manager: " + err.Error())
 	}

--- a/server/client_resource_test.go
+++ b/server/client_resource_test.go
@@ -188,7 +188,7 @@ func TestList(t *testing.T) {
 	}{
 		// empty repo
 		{
-			cs:   nil,
+			cs:   []client.Client{},
 			want: nil,
 		},
 		// single client
@@ -244,20 +244,14 @@ func TestList(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		dbm := db.NewMemDB()
-		clientIDGenerator := func(hostport string) (string, error) {
-			return hostport, nil
-		}
-		secGen := func() ([]byte, error) {
-			return []byte("secret"), nil
-		}
-		clientRepo := db.NewClientRepo(dbm)
-		clientManager, err := manager.NewClientManagerFromClients(clientRepo, db.TransactionFactory(dbm), tt.cs, manager.ManagerOptions{ClientIDGenerator: clientIDGenerator, SecretGenerator: secGen})
+		f, err := makeTestFixturesWithOptions(testFixtureOptions{
+			clients: tt.cs,
+		})
 		if err != nil {
-			t.Fatalf("Failed to create client identity manager: %v", err)
-			continue
+			t.Fatalf("error making test fixtures: %v", err)
 		}
-		res := &clientResource{manager: clientManager}
+
+		res := &clientResource{manager: f.clientManager}
 
 		r, err := http.NewRequest("GET", "http://example.com/clients", nil)
 		if err != nil {

--- a/server/config.go
+++ b/server/config.go
@@ -116,10 +116,9 @@ func (cfg *SingleServerConfig) Configure(srv *Server) error {
 		return fmt.Errorf("unable to read clients from file %s: %v", cfg.ClientsFile, err)
 	}
 
-	clientRepo := db.NewClientRepo(dbMap)
-
-	for _, c := range clients {
-		clientRepo.New(nil, c)
+	clientRepo, err := db.NewClientRepoFromClients(dbMap, clients)
+	if err != nil {
+		return err
 	}
 
 	f, err := os.Open(cfg.ConnectorsFile)
@@ -158,7 +157,7 @@ func (cfg *SingleServerConfig) Configure(srv *Server) error {
 
 	txnFactory := db.TransactionFactory(dbMap)
 	userManager := usermanager.NewUserManager(userRepo, pwiRepo, cfgRepo, txnFactory, usermanager.ManagerOptions{})
-	clientManager, err := clientmanager.NewClientManagerFromClients(clientRepo, db.TransactionFactory(dbMap), clients, clientmanager.ManagerOptions{})
+	clientManager := clientmanager.NewClientManager(clientRepo, db.TransactionFactory(dbMap), clientmanager.ManagerOptions{})
 	if err != nil {
 		return fmt.Errorf("Failed to create client identity manager: %v", err)
 	}

--- a/server/testutil.go
+++ b/server/testutil.go
@@ -180,11 +180,13 @@ func makeTestFixturesWithOptions(options testFixtureOptions) (*testFixtures, err
 	secGen := func() ([]byte, error) {
 		return []byte("secret"), nil
 	}
-	clientRepo := db.NewClientRepo(dbMap)
-	clientManager, err := clientmanager.NewClientManagerFromClients(clientRepo, db.TransactionFactory(dbMap), clients, clientmanager.ManagerOptions{ClientIDGenerator: clientIDGenerator, SecretGenerator: secGen})
+	clientRepo, err := db.NewClientRepoFromClients(dbMap, clients)
 	if err != nil {
 		return nil, err
 	}
+
+	clientManager := clientmanager.NewClientManager(clientRepo, db.TransactionFactory(dbMap), clientmanager.ManagerOptions{ClientIDGenerator: clientIDGenerator, SecretGenerator: secGen})
+
 	km := key.NewPrivateKeyManager()
 	err = km.Set(key.NewPrivateKeySet([]*key.PrivateKey{testPrivKey}, time.Now().Add(time.Minute)))
 	if err != nil {

--- a/server/testutil.go
+++ b/server/testutil.go
@@ -95,6 +95,10 @@ type testFixtures struct {
 	clientManager  *clientmanager.ClientManager
 }
 
+type testFixtureOptions struct {
+	clients []client.Client
+}
+
 func sequentialGenerateCodeFunc() sessionmanager.GenerateCodeFunc {
 	x := 0
 	return func() (string, error) {
@@ -104,6 +108,10 @@ func sequentialGenerateCodeFunc() sessionmanager.GenerateCodeFunc {
 }
 
 func makeTestFixtures() (*testFixtures, error) {
+	return makeTestFixturesWithOptions(testFixtureOptions{})
+}
+
+func makeTestFixturesWithOptions(options testFixtureOptions) (*testFixtures, error) {
 	dbMap := db.NewMemDB()
 	userRepo, err := db.NewUserRepoFromUsers(dbMap, testUsers)
 	if err != nil {
@@ -150,15 +158,20 @@ func makeTestFixtures() (*testFixtures, error) {
 		return nil, err
 	}
 
-	clients := []client.Client{
-		client.Client{
-			Credentials: testClientCredentials,
-			Metadata: oidc.ClientMetadata{
-				RedirectURIs: []url.URL{
-					testRedirectURL,
+	var clients []client.Client
+	if options.clients == nil {
+		clients = []client.Client{
+			client.Client{
+				Credentials: testClientCredentials,
+				Metadata: oidc.ClientMetadata{
+					RedirectURIs: []url.URL{
+						testRedirectURL,
+					},
 				},
 			},
-		},
+		}
+	} else {
+		clients = options.clients
 	}
 
 	clientIDGenerator := func(hostport string) (string, error) {

--- a/server/testutil.go
+++ b/server/testutil.go
@@ -26,21 +26,33 @@ const (
 )
 
 var (
+	testUserID1       = "ID-1"
+	testUserEmail1    = "Email-1@example.com"
+	testUserRemoteID1 = "RID-1"
+
 	testIssuerURL = url.URL{Scheme: "http", Host: "server.example.com"}
-	testClientID  = "client.example.com"
+
+	testClientID          = "client.example.com"
+	clientTestSecret      = base64.URLEncoding.EncodeToString([]byte("secret"))
+	testClientCredentials = oidc.ClientCredentials{
+		ID:     testClientID,
+		Secret: clientTestSecret,
+	}
+
+	testConnectorID1 = "IDPC-1"
 
 	testRedirectURL = url.URL{Scheme: "http", Host: "client.example.com", Path: "/callback"}
 
 	testUsers = []user.UserWithRemoteIdentities{
 		{
 			User: user.User{
-				ID:    "ID-1",
-				Email: "Email-1@example.com",
+				ID:    testUserID1,
+				Email: testUserEmail1,
 			},
 			RemoteIdentities: []user.RemoteIdentity{
 				{
-					ConnectorID: "IDPC-1",
-					ID:          "RID-1",
+					ConnectorID: testConnectorID1,
+					ID:          testUserRemoteID1,
 				},
 			},
 		},
@@ -140,10 +152,7 @@ func makeTestFixtures() (*testFixtures, error) {
 
 	clients := []client.Client{
 		client.Client{
-			Credentials: oidc.ClientCredentials{
-				ID:     testClientID,
-				Secret: base64.URLEncoding.EncodeToString([]byte("secret")),
-			},
+			Credentials: testClientCredentials,
 			Metadata: oidc.ClientMetadata{
 				RedirectURIs: []url.URL{
 					testRedirectURL,

--- a/test
+++ b/test
@@ -18,7 +18,7 @@ if [ ! -d $GOPATH/pkg ]; then
 	echo "WARNING: No cached builds detected. Please run the ./build script to speed up future tests."
 fi
 
-TESTABLE="connector db integration pkg/crypto pkg/flag pkg/http pkg/time pkg/html functional/repo server session session/manager user user/api user/manager user/email email admin client client/manager"
+TESTABLE="admin client client/manager connector db email functional/repo integration pkg/crypto pkg/flag pkg/http pkg/time pkg/html server session session/manager user user/api user/manager user/email"
 FORMATTABLE="$TESTABLE cmd/dexctl cmd/dex-worker cmd/dex-overlord examples/app functional pkg/log"
 
 # user has not provided PKG override

--- a/test-functional
+++ b/test-functional
@@ -4,3 +4,4 @@ source ./env
 
 go test $@ github.com/coreos/dex/functional
 go test $@ github.com/coreos/dex/functional/repo
+go test $@ github.com/coreos/dex/functional/config

--- a/user/api/api_test.go
+++ b/user/api/api_test.go
@@ -176,11 +176,11 @@ func makeTestFixtures() (*UsersAPI, *testEmailer) {
 	secGen := func() ([]byte, error) {
 		return []byte("secret"), nil
 	}
-	clientRepo := db.NewClientRepo(dbMap)
-	clientManager, err := clientmanager.NewClientManagerFromClients(clientRepo, db.TransactionFactory(dbMap), []client.Client{ci}, clientmanager.ManagerOptions{ClientIDGenerator: clientIDGenerator, SecretGenerator: secGen})
+	clientRepo, err := db.NewClientRepoFromClients(dbMap, []client.Client{ci})
 	if err != nil {
 		panic("Failed to create client manager: " + err.Error())
 	}
+	clientManager := clientmanager.NewClientManager(clientRepo, db.TransactionFactory(dbMap), clientmanager.ManagerOptions{ClientIDGenerator: clientIDGenerator, SecretGenerator: secGen})
 
 	// Used in TestRevokeRefreshToken test.
 	refreshTokens := []struct {


### PR DESCRIPTION
* change generateClientCreds to addClientCreds - more accurate reflection of the API
* add test to make sure that clients in sample file are valid, and that they can be authenticated against (this makes me worry less about screwing up the encoding/hashing of client_secrets)
* in preparation for removing ClientManagerFromClients, fix up a lot of copy-pasta in server tests and use testutil code instead to create fixtures
* finally, remove ClientManagerFromClients, in favor of a similar method in the repo layer