### PR TITLE
#400 Add connector id to the registration error message

### DIFF
--- a/cmd/dex-worker/main.go
+++ b/cmd/dex-worker/main.go
@@ -191,7 +191,7 @@ func main() {
 	for _, cfg := range cfgs {
 		cfg := cfg
 		if err = srv.AddConnector(cfg); err != nil {
-			log.Fatalf("Failed registering connector: %v", err)
+			log.Fatalf("Failed registering connector '%s': %v", cfg.ConnectorID(), err)
 		}
 	}
 


### PR DESCRIPTION
Right now it is not clear what connector is failing. It will be easier to debug with more specific error message.

Related to #400