### PR TITLE
*: add --enable-automatic-registration flag to worker

### DIFF
--- a/cmd/dex-worker/main.go
+++ b/cmd/dex-worker/main.go
@@ -46,7 +46,9 @@ func main() {
 	emailFrom := fs.String("email-from", "", "emails sent from dex will come from this address")
 	emailConfig := fs.String("email-cfg", "./static/fixtures/emailer.json", "configures emailer.")
 
-	enableRegistration := fs.Bool("enable-registration", false, "Allows users to self-register")
+	enableRegistration := fs.Bool("enable-registration", false, "Allows users to self-register. This flag cannot be used in combination with --enable-automatic-registration.")
+	registerOnFirstLogin := fs.Bool("enable-automatic-registration", false, "When a user logs in through a federated identity service, automatically register them if they don't have an account. This flag cannot be used in combination with --enable-registration.")
+
 	enableClientRegistration := fs.Bool("enable-client-registration", false, "Allow dynamic registration of clients")
 
 	noDB := fs.Bool("no-db", false, "manage entities in-process w/o any encryption, used only for single-node testing")
@@ -88,6 +90,11 @@ func main() {
 	if *printVersion {
 		fmt.Printf("dex version %s\ngo version %s\n", strings.TrimPrefix(version, "v"), strings.TrimPrefix(runtime.Version(), "go"))
 		os.Exit(0)
+	}
+
+	if (*enableRegistration) && (*registerOnFirstLogin) {
+		fmt.Fprintln(os.Stderr, "The flags --enable-registration and --enable-automatic-login cannot both be true.")
+		os.Exit(1)
 	}
 
 	if *logDebug {
@@ -135,6 +142,7 @@ func main() {
 		IssuerLogoURL:            *issuerLogoURL,
 		EnableRegistration:       *enableRegistration,
 		EnableClientRegistration: *enableClientRegistration,
+		RegisterOnFirstLogin:     *registerOnFirstLogin,
 	}
 
 	if *noDB {

--- a/server/config.go
+++ b/server/config.go
@@ -38,6 +38,7 @@ type ServerConfig struct {
 	StateConfig              StateConfigurer
 	EnableRegistration       bool
 	EnableClientRegistration bool
+	RegisterOnFirstLogin     bool
 }
 
 type StateConfigurer interface {
@@ -78,6 +79,7 @@ func (cfg *ServerConfig) Server() (*Server, error) {
 
 		EnableRegistration:       cfg.EnableRegistration,
 		EnableClientRegistration: cfg.EnableClientRegistration,
+		RegisterOnFirstLogin:     cfg.RegisterOnFirstLogin,
 	}
 
 	err = cfg.StateConfig.Configure(&srv)

--- a/server/testutil_test.go
+++ b/server/testutil_test.go
@@ -54,6 +54,10 @@ var (
 
 	testConnectorID1 = "IDPC-1"
 
+	testConnectorIDOpenID        = "oidc"
+	testConnectorIDOpenIDTrusted = "oidc-trusted"
+	testConnectorLocalID         = "local"
+
 	testRedirectURL = url.URL{Scheme: "http", Host: "client.example.com", Path: "/callback"}
 
 	testUsers = []user.UserWithRemoteIdentities{
@@ -143,20 +147,27 @@ func makeTestFixturesWithOptions(options testFixtureOptions) (*testFixtures, err
 
 	connConfigs := []connector.ConnectorConfig{
 		&connector.OIDCConnectorConfig{
-			ID:           "oidc",
+			ID:           testConnectorIDOpenID,
 			IssuerURL:    testIssuerURL.String(),
 			ClientID:     "12345",
 			ClientSecret: "567789",
 		},
 		&connector.OIDCConnectorConfig{
-			ID:                   "oidc-trusted",
+			ID:                   testConnectorIDOpenIDTrusted,
 			IssuerURL:            testIssuerURL.String(),
 			ClientID:             "12345-trusted",
 			ClientSecret:         "567789-trusted",
 			TrustedEmailProvider: true,
 		},
+		&connector.OIDCConnectorConfig{
+			ID:                   testConnectorID1,
+			IssuerURL:            testIssuerURL.String(),
+			ClientID:             testConnectorID1 + "_client_id",
+			ClientSecret:         testConnectorID1 + "_client_secret",
+			TrustedEmailProvider: true,
+		},
 		&connector.LocalConnectorConfig{
-			ID: "local",
+			ID: testConnectorLocalID,
 		},
 	}
 	connCfgRepo := db.NewConnectorConfigRepo(dbMap)


### PR DESCRIPTION
When specified the "--register-on-first-login" allows users logging in through remote connectors to skip registration. This make a lot of sense for connectors like LDAP, which have their own registration upstream.

Closes #310

This change also renames "server/testutil.go" to "server/testutil_test.go" to ensure it's not used outside of tests.

cc @sym3tri