### PR TITLE
vendor: update go-oidc to add support for Azure AD

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: 7e7b258be2aa7e03d1bb15c96f856a9b7982d850a1faeba699a0b11bcb0c6936
-updated: 2016-05-27T00:22:02.656877293+02:00
+hash: af5ee807138ecd53eebc54567b4dcd66e3a6ddc7d758fb9f34e6e3eb13b20cf2
+updated: 2016-06-13T10:58:04.608971954+09:00
 imports:
 - name: github.com/andybalholm/cascadia
   version: 6122e68c2642b7b75c538a63b15168c6c80fb757
 - name: github.com/coreos/go-oidc
-  version: e6174c764e906bd60c76fdfc33faf5e0bdc875d6
+  version: 8ae400b75540a4f57ec549a89b3e9d994c636f2a
   subpackages:
   - http
   - jose

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/andybalholm/cascadia
   version: 6122e68c2642b7b75c538a63b15168c6c80fb757
 - package: github.com/coreos/go-oidc
-  version: e6174c764e906bd60c76fdfc33faf5e0bdc875d6
+  version: 8ae400b75540a4f57ec549a89b3e9d994c636f2a
   subpackages:
   - http
   - jose

--- a/vendor/github.com/coreos/go-oidc/oauth2/oauth2.go
+++ b/vendor/github.com/coreos/go-oidc/oauth2/oauth2.go
@@ -332,16 +332,16 @@ func parseTokenResponse(resp *http.Response) (result TokenResponse, err error) {
 		result.Scope = vals.Get("scope")
 	} else {
 		var r struct {
-			AccessToken  string `json:"access_token"`
-			TokenType    string `json:"token_type"`
-			IDToken      string `json:"id_token"`
-			RefreshToken string `json:"refresh_token"`
-			Scope        string `json:"scope"`
-			State        string `json:"state"`
-			ExpiresIn    int    `json:"expires_in"`
-			Expires      int    `json:"expires"`
-			Error        string `json:"error"`
-			Desc         string `json:"error_description"`
+			AccessToken  string      `json:"access_token"`
+			TokenType    string      `json:"token_type"`
+			IDToken      string      `json:"id_token"`
+			RefreshToken string      `json:"refresh_token"`
+			Scope        string      `json:"scope"`
+			State        string      `json:"state"`
+			ExpiresIn    json.Number `json:"expires_in"` // Azure AD returns string
+			Expires      int         `json:"expires"`
+			Error        string      `json:"error"`
+			Desc         string      `json:"error_description"`
 		}
 		if err = json.Unmarshal(body, &r); err != nil {
 			return
@@ -355,10 +355,10 @@ func parseTokenResponse(resp *http.Response) (result TokenResponse, err error) {
 		result.IDToken = r.IDToken
 		result.RefreshToken = r.RefreshToken
 		result.Scope = r.Scope
-		if r.ExpiresIn == 0 {
+		if expiresIn, err := r.ExpiresIn.Int64(); err != nil {
 			result.Expires = r.Expires
 		} else {
-			result.Expires = r.ExpiresIn
+			result.Expires = int(expiresIn)
 		}
 	}
 	return

--- a/vendor/github.com/coreos/go-oidc/oauth2/oauth2_test.go
+++ b/vendor/github.com/coreos/go-oidc/oauth2/oauth2_test.go
@@ -439,6 +439,20 @@ func TestParseTokenResponse(t *testing.T) {
 			},
 		},
 		{
+			// Azure AD returns "expires_in" value as string
+			resp: response{
+				body:        `{"access_token":"foo","id_token":"bar","expires_in":"300","token_type":"bearer","refresh_token":"spam"}`,
+				contentType: "application/json; charset=utf-8",
+			},
+			wantResp: TokenResponse{
+				AccessToken:  "foo",
+				IDToken:      "bar",
+				Expires:      300,
+				TokenType:    "bearer",
+				RefreshToken: "spam",
+			},
+		},
+		{
 			resp: response{
 				body:        `{"access_token":"foo","id_token":"bar","expires":200,"token_type":"bearer","refresh_token":"spam"}`,
 				contentType: "application/json; charset=utf-8",


### PR DESCRIPTION
Update github.com/coreos/go-oidc/ to include coreos/go-oidc#87
which adds support for Azure AD