### PR TITLE
Clean up LDAP Connector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ go:
 env:
   - DEX_TEST_DSN="postgres://postgres@127.0.0.1:15432/postgres?sslmode=disable" ISOLATED=true
     DEX_TEST_LDAP_HOST="tlstest.local:1389"
+    DEX_TEST_LDAPS_HOST="tlstest.local:1636"
     DEX_TEST_LDAP_BINDNAME="cn=admin,dc=example,dc=org"
     DEX_TEST_LDAP_BINDPASS="admin"
 

--- a/Documentation/connectors-configuration.md
+++ b/Documentation/connectors-configuration.md
@@ -15,7 +15,7 @@ The dex connector configuration format is a JSON array of objects, each with an 
         "id": "Google",
         "type": "oidc",
         ...<<more config>>...
-    } 
+    }
 ]
 ```
 
@@ -45,11 +45,8 @@ The configuration for the local connector is always the same; it looks like this
 This connector config lets users authenticate with other OIDC providers. In addition to `id` and `type`, the `oidc` connector takes the following additional fields:
 
 * issuerURL: a `string`. The base URL for the OIDC provider. Should be a URL with an `https` scheme.
-
 * clientID: a `string`. The OIDC client ID.
-
 * clientSecret: a `string`. The OIDC client secret.
-
 * trustedEmailProvider: a `boolean`. If true dex will trust the email address claims from this provider and not require that users verify their emails.
 
 In order to use the `oidc` connector you must register dex as an OIDC client; this mechanism is different from provider to provider. For Google, follow the instructions at their [developer site](https://developers.google.com/identity/protocols/OpenIDConnect?hl=en). Regardless of your provider, registering your client will also provide you with the client ID and secret.
@@ -80,7 +77,6 @@ Here's what a `oidc` connector looks like configured for authenticating with Goo
 This connector config lets users authenticate through [GitHub](https://github.com/). In addition to `id` and `type`, the `github` connector takes the following additional fields:
 
 * clientID: a `string`. The GitHub OAuth application client ID.
-
 * clientSecret: a `string`. The GitHub OAuth application client secret.
 
 To begin, register an OAuth application with GitHub through your, or your organization's [account settings](ttps://github.com/settings/applications/new). To register dex as a client of your GitHub application, enter dex's redirect URL under 'Authorization callback URL':
@@ -109,10 +105,9 @@ The `github` connector requests read only access to user's email through the [`u
 This connector config lets users authenticate through [Bitbucket](https://bitbucket.org/). In addition to `id` and `type`, the `bitbucket` connector takes the following additional fields:
 
 * clientID: a `string`. The Bitbucket OAuth consumer client ID.
-
 * clientSecret: a `string`. The Bitbucket OAuth consumer client secret.
 
-To begin, register an OAuth consumer with Bitbucket through your, or your teams's management page. Follow the documentation at their [developer site](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html). 
+To begin, register an OAuth consumer with Bitbucket through your, or your teams's management page. Follow the documentation at their [developer site](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html).
 __NOTE:__ When configuring a consumer through Bitbucket you _must_ configure read email permissions.
 
 To register dex as a client of your Bitbucket consumer, enter dex's redirect URL under 'Callback URL':
@@ -136,82 +131,84 @@ Here's an example of a `bitbucket` connector; the clientID and clientSecret shou
 
 ### `ldap` connector
 
-The `ldap` connector allows email/password based authentication hosted by dex, backed by a LDAP directory.
+The `ldap` connector allows email/password based authentication hosted by dex, backed by a LDAP directory. The connector can operate in two primary modes:
 
-Authentication is performed by binding to the configured LDAP server using the user supplied credentials. Successfull bind equals authenticated user.
+1. Binding against a specific directory using the end user's credentials.
+2. Searching a directory for a entry using a service account then attempting to bind with the user's credentials.
 
-Optionally the connector can be configured to search before authentication. The entryDN found will be used to bind to the LDAP server.
+User entries are expected to have an email attribute (configurable through "emailAttribute"), and optionally a display name attribute (configurable through "nameAttribute").
 
-This feature must be enabled to get supplementary information from the directory (ID, Name, Email). This feature can also be used to limit access to the service.
-
-Example use case: Allow your users to log in with e-mail address as username instead of the identification string in your DNs (typically username).
-
-___NOTE:___ Users must register with dex at first login. For this to work you have to run dex-worker with --enable-registration.
+___NOTE:___ Dex currently requires user registration with the dex system, even if that user already has an account with the upstream LDAP system. Installations that use this connector are recommended to provide the "--enable-automatic-registration" flag.
 
 In addition to `id` and `type`, the `ldap` connector takes the following additional fields:
-* serverHost: a `string`. The hostname for the LDAP Server.
 
-* serverPort: a `unsigned 16-bit integer`. The port for the LDAP Server.
-
-* timeout: `duration in milliseconds`. The timeout for connecting to and reading from LDAP Server in Milliseconds. Default: `60000` (60 Seconds)
-
+* host: a `string`. The host and port of the LDAP server in form "host:port".
 * useTLS: a `boolean`. Whether the LDAP Connector should issue a StartTLS after successfully connecting to the LDAP Server.
-
 * useSSL: a `boolean`. Whether the LDAP Connector should expect the connection to be encrypted, typically used with ldaps port (636/tcp).
-
-* certFile: a `string`. Optional Certificate to present to LDAP server.
-
-* keyFile: a `string`. Key associated with Certificate specified in `certFile`.
-
+* certFile: a `string`. Optional path to x509 client certificate to present to LDAP server.
+* keyFile: a `string`. Key associated with x509 client cert specified in `certFile`.
 * caFile: a `string`. Filename for PEM-file containing the set of root certificate authorities that the LDAP client use when verifying the server certificates. Default: use the host's root CA set.
-
-* skipCertVerification: a `boolean`. Skip server certificate chain verification.
-
-* maxIdleConn: a `integer`. Maximum number of idle LDAP Connections to keep in connection pool. Default: `5`
-
 * baseDN: a `string`. Base DN from which Bind DN is built and searches are based.
-
-* nameAttribute: a `string`. Attribute to map to Name. Default: `cn`
-
-* emailAttribute: a `string`. Attribute to map to Email. Default: `mail`
-
+* nameAttribute: a `string`. Entity attribute to map to display name of users. Default: `cn`
+* emailAttribute: a `string`. Required. Attribute to map to Email. Default: `mail`
 * searchBeforeAuth: a `boolean`. Perform search for entryDN to be used for bind.
-
-* searchFilter: a `string`. Filter to apply to search. Variable substititions: `%u` User supplied username/e-mail address. `%b` BaseDN.
-
+* searchFilter: a `string`. Filter to apply to search. Variable substititions: `%u` User supplied username/e-mail address. `%b` BaseDN. Searches that return multiple entries are considered ambiguous and will return an error.
 * searchScope: a `string`. Scope of the search. `base|one|sub`. Default: `one`
-
 * searchBindDN: a `string`. DN to bind as for search operations.
-
 * searchBindPw: a `string`. Password for bind for search operations.
+* bindTemplate: a `string`. Template to build bindDN from user supplied credentials. Variable subtitutions: `%u` User supplied username/e-mail address. `%b` BaseDN. Default: `uid=%u,%b`.
 
-* bindTemplate: a `string`. Template to build bindDN from user supplied credentials. Variable subtitutions: `%u` User supplied username/e-mail address. `%b` BaseDN. Default: `uid=%u,%b` ___NOTE:___ This is not used when searchBeforeAuth is enabled.
+### Example: Authenticating against a specific directory
 
-* trustedEmailProvider: a `boolean`. If true dex will trust the email address claims from this provider and not require that users verify their emails.
-
-Here's an example of a `ldap` connector;
+To authenticate against a specific LDAP directory level, use the "bindTemplate" field. This string describes how to map a username to a LDAP entity.
 
 ```
     {
         "type": "ldap",
         "id": "ldap",
-        "serverHost": "127.0.0.1",
-        "serverPort": 389,
-        "useTLS": true,
-        "useSSL": false,
-        "skipCertVerification": false,
-        "baseDN": "ou=People,dc=example,dc=com",
-        "nameAttribute": "cn",
-        "emailAttribute": "mail",
-        "searchBeforeAuth": true,
-        "searchFilter": "(mail=%u)",
-        "searchScope": "one",
-        "searchBindDN": "searchuser",
-        "searchBindPw": "supersecret",
-        "bindTemplate": "uid=%u,%b",
-        "trustedEmailProvider": true
+        "host": "127.0.0.1:389",
+        "baseDN": "cn=users,cn=accounts,dc=auth,dc=example,dc=com",
+        "bindTemplate": "uid=%u,%d"
     }
 ```
+
+"bindTemplate" is a format string. `%d` is replaced by the value of "baseDN" and `%u` is replaced by the username attempting to login. In this case if a user "janedoe" attempts to authenticate, the bindTemplate will be expanded to:
+
+```
+uid=janedoe,cn=users,cn=accounts,dc=auth,dc=example,dc=com
+```
+
+The connector then attempts to bind as this entry using the password provided by the end user.
+
+### Example: Searching the directory
+
+The following configuration will search a directory using an LDAP filter. With FreeIPA
+
+```
+    {
+        "type": "ldap",
+        "id": "ldap",
+        "host": "127.0.0.1:389",
+        "baseDN": "cn=auth,dc=example,dc=com",
+
+        "searchBeforeAuth": true,
+        "searchFilter": "(&(objectClass=person)(uid=%u))",
+        "searchScope": "sub",
+
+        "searchBindDN": "serviceAccountUser",
+        "searchBindPw": "serviceAccountPassword"
+    }
+```
+
+"searchFilter" is a format string expanded in a similar manner as "bindTemplate". If the user "janedoe" attempts to authenticate, the connector will run the following query using the service account credentials.
+
+```
+(&(objectClass=person)(uid=janedoe))
+```
+
+If the search finds an entry, it will attempt to use the provided password to bind as that entry.
+
+__NOTE__: Searches that return multiple entries will return an error.
 
 ## Setting the Configuration
 

--- a/connector/connector_ldap_test.go
+++ b/connector/connector_ldap_test.go
@@ -21,6 +21,7 @@ func init() {
 func TestLDAPConnectorConfigValidTLS(t *testing.T) {
 	cc := LDAPConnectorConfig{
 		ID:     "ldap",
+		Host:   "example.com:636",
 		UseTLS: true,
 		UseSSL: false,
 	}
@@ -34,6 +35,7 @@ func TestLDAPConnectorConfigValidTLS(t *testing.T) {
 func TestLDAPConnectorConfigInvalidSSLandTLS(t *testing.T) {
 	cc := LDAPConnectorConfig{
 		ID:     "ldap",
+		Host:   "example.com:636",
 		UseTLS: true,
 		UseSSL: true,
 	}
@@ -47,6 +49,7 @@ func TestLDAPConnectorConfigInvalidSSLandTLS(t *testing.T) {
 func TestLDAPConnectorConfigValidSearchScope(t *testing.T) {
 	cc := LDAPConnectorConfig{
 		ID:          "ldap",
+		Host:        "example.com:636",
 		SearchScope: "one",
 	}
 
@@ -59,6 +62,7 @@ func TestLDAPConnectorConfigValidSearchScope(t *testing.T) {
 func TestLDAPConnectorConfigInvalidSearchScope(t *testing.T) {
 	cc := LDAPConnectorConfig{
 		ID:          "ldap",
+		Host:        "example.com:636",
 		SearchScope: "three",
 	}
 
@@ -71,6 +75,7 @@ func TestLDAPConnectorConfigInvalidSearchScope(t *testing.T) {
 func TestLDAPConnectorConfigInvalidCertFileNoKeyFile(t *testing.T) {
 	cc := LDAPConnectorConfig{
 		ID:       "ldap",
+		Host:     "example.com:636",
 		CertFile: "/tmp/ldap.crt",
 	}
 
@@ -83,6 +88,7 @@ func TestLDAPConnectorConfigInvalidCertFileNoKeyFile(t *testing.T) {
 func TestLDAPConnectorConfigValidCertFileAndKeyFile(t *testing.T) {
 	cc := LDAPConnectorConfig{
 		ID:       "ldap",
+		Host:     "example.com:636",
 		CertFile: "/tmp/ldap.crt",
 		KeyFile:  "/tmp/ldap.key",
 	}

--- a/connector/connector_local.go
+++ b/connector/connector_local.go
@@ -87,7 +87,7 @@ func (c *LocalConnector) LoginURL(sessionKey, prompt string) (string, error) {
 
 func (c *LocalConnector) Register(mux *http.ServeMux, errorURL url.URL) {
 	route := c.namespace.Path + "/login"
-	mux.Handle(route, handleLoginFunc(c.loginFunc, c.loginTpl, c.idp, route, errorURL))
+	mux.Handle(route, handlePasswordLogin(c.loginFunc, c.loginTpl, c.idp, route, errorURL))
 }
 
 func (c *LocalConnector) Sync() chan struct{} {

--- a/connector/interface.go
+++ b/connector/interface.go
@@ -65,7 +65,3 @@ type ConnectorConfigRepo interface {
 	GetConnectorByID(repo.Transaction, string) (ConnectorConfig, error)
 	Set(cfgs []ConnectorConfig) error
 }
-
-type IdentityProvider interface {
-	Identity(email, password string) (*oidc.Identity, error)
-}

--- a/functional/ldap_test.go
+++ b/functional/ldap_test.go
@@ -1,12 +1,9 @@
 package functional
 
 import (
-	"fmt"
 	"html/template"
-	"net"
 	"net/url"
 	"os"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -16,45 +13,41 @@ import (
 	"gopkg.in/ldap.v2"
 )
 
-var (
-	ldapHost   string
-	ldapPort   uint16
-	ldapBindDN string
-	ldapBindPw string
-)
-
 type LDAPServer struct {
-	Host   string
-	Port   uint16
-	BindDN string
-	BindPw string
+	Host      string // Address (host:port) of LDAP service.
+	LDAPSHost string // Address (host:port) of LDAPS service (TLS port).
+	BindDN    string
+	BindPw    string
 }
 
 const (
-	ldapEnvHost     = "DEX_TEST_LDAP_HOST"
+	ldapEnvHost  = "DEX_TEST_LDAP_HOST"
+	ldapsEnvHost = "DEX_TEST_LDAPS_HOST"
+
 	ldapEnvBindName = "DEX_TEST_LDAP_BINDNAME"
 	ldapEnvBindPass = "DEX_TEST_LDAP_BINDPASS"
 )
 
 func ldapServer(t *testing.T) LDAPServer {
-	host := os.Getenv(ldapEnvHost)
-	if host == "" {
-		t.Fatalf("%s not set", ldapEnvHost)
-	}
-	var port uint64 = 389
-	if h, p, err := net.SplitHostPort(host); err == nil {
-		port, err = strconv.ParseUint(p, 10, 16)
-		if err != nil {
-			t.Fatalf("failed to parse port: %v", err)
+	getenv := func(key string) string {
+		val := os.Getenv(key)
+		if val == "" {
+			t.Fatalf("%s not set", key)
 		}
-		host = h
+		t.Logf("%s=%v", key, val)
+		return val
 	}
-	return LDAPServer{host, uint16(port), os.Getenv(ldapEnvBindName), os.Getenv(ldapEnvBindPass)}
+	return LDAPServer{
+		Host:      getenv(ldapEnvHost),
+		LDAPSHost: getenv(ldapsEnvHost),
+		BindDN:    os.Getenv(ldapEnvBindName),
+		BindPw:    os.Getenv(ldapEnvBindPass),
+	}
 }
 
 func TestLDAPConnect(t *testing.T) {
 	server := ldapServer(t)
-	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", server.Host, server.Port))
+	l, err := ldap.Dial("tcp", server.Host)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,39 +67,35 @@ func TestConnectorLDAPHealthy(t *testing.T) {
 	}{
 		{
 			config: connector.LDAPConnectorConfig{
-				ID:         "ldap",
-				ServerHost: server.Host,
-				ServerPort: server.Port + 1,
+				ID:   "ldap",
+				Host: "localhost:0",
 			},
 			wantErr: true,
 		},
 		{
 			config: connector.LDAPConnectorConfig{
-				ID:         "ldap",
-				ServerHost: server.Host,
-				ServerPort: server.Port,
+				ID:   "ldap",
+				Host: server.Host,
 			},
 		},
 		{
 			config: connector.LDAPConnectorConfig{
-				ID:         "ldap",
-				ServerHost: server.Host,
-				ServerPort: server.Port,
-				UseTLS:     true,
-				CertFile:   "/tmp/ldap.crt",
-				KeyFile:    "/tmp/ldap.key",
-				CaFile:     "/tmp/openldap-ca.pem",
+				ID:       "ldap",
+				Host:     server.Host,
+				UseTLS:   true,
+				CertFile: "/tmp/ldap.crt",
+				KeyFile:  "/tmp/ldap.key",
+				CaFile:   "/tmp/openldap-ca.pem",
 			},
 		},
 		{
 			config: connector.LDAPConnectorConfig{
-				ID:         "ldap",
-				ServerHost: server.Host,
-				ServerPort: server.Port + 247, // 636
-				UseSSL:     true,
-				CertFile:   "/tmp/ldap.crt",
-				KeyFile:    "/tmp/ldap.key",
-				CaFile:     "/tmp/openldap-ca.pem",
+				ID:       "ldap",
+				Host:     server.LDAPSHost,
+				UseSSL:   true,
+				CertFile: "/tmp/ldap.crt",
+				KeyFile:  "/tmp/ldap.key",
+				CaFile:   "/tmp/openldap-ca.pem",
 			},
 		},
 	}
@@ -131,8 +120,7 @@ func TestLDAPPoolHighWatermarkAndLockContention(t *testing.T) {
 	server := ldapServer(t)
 	ldapPool := &connector.LDAPPool{
 		MaxIdleConn: 30,
-		ServerHost:  server.Host,
-		ServerPort:  server.Port,
+		Host:        server.Host,
 		UseTLS:      false,
 		UseSSL:      false,
 	}
@@ -151,17 +139,16 @@ func TestLDAPPoolHighWatermarkAndLockContention(t *testing.T) {
 				case <-ctx.Done():
 					return
 				default:
-					ldapConn, err := ldapPool.Acquire()
-					if err != nil {
-						t.Errorf("Unable to acquire LDAP Connection: %v", err)
-					}
-					s := ldap.NewSearchRequest("", ldap.ScopeBaseObject, ldap.NeverDerefAliases, 0, 0, false, "(objectClass=*)", []string{}, nil)
-					_, err = ldapConn.Search(s)
+					err := ldapPool.Do(func(conn *ldap.Conn) error {
+						s := &ldap.SearchRequest{
+							Scope:  ldap.ScopeBaseObject,
+							Filter: "(objectClass=*)",
+						}
+						_, err := conn.Search(s)
+						return err
+					})
 					if err != nil {
 						t.Errorf("Search request failed. Dead/invalid LDAP connection from pool?: %v", err)
-						ldapConn.Close()
-					} else {
-						ldapPool.Put(ldapConn)
 					}
 					_, _ = ldapPool.CheckConnections()
 				}

--- a/static/fixtures/connectors.json.sample
+++ b/static/fixtures/connectors.json.sample
@@ -25,8 +25,7 @@
 	{
 		"type": "ldap",
 		"id": "ldap",
-		"serverHost": "127.0.0.1",
-		"serverPort": 389,
+		"host": "127.0.0.1:389",
 		"useTLS": true,
 		"useSSL": false,
 		"caFile": "/etc/ssl/certs/example_com_root.crt",


### PR DESCRIPTION
The first commit cleans up the LDAP connector a bit. A follow up one will add the groups implementation.

Cleanup includes:
* Remove some unlikely to be used fields to help configurability.
  * Combined "serverHost" and "serverPort" into "host"
  * Remove "timeout" (just default to 30 seconds).
  * Remove "maxIdleConn" will add it back if users feel the need
    to control the number of cached connections.
  * Remove "trustedEmailProvider" (just always trust).
  * Remove "skipCertVerification" you can't make this connector
    ingore TLS errors.
* Fix configs that don't search before bind (fixes #481).
* Add more examples to Documentation
* Refactor LDAPPool Acquire() and Put() into a Do() function which
  always does the flow correctly.
* Added more comments and renamed some functions.

Edit:

* Moved methods on LDAPIdentityProvider to the LDAPConnector