### PR TITLE
scope: don't validate empty scopes

### DIFF
--- a/scope/scope.go
+++ b/scope/scope.go
@@ -41,6 +41,9 @@ func (s Scopes) Contains(other Scopes) bool {
 
 	for _, scope := range other {
 		if _, ok := rScopes[scope]; !ok {
+			if scope == "" {
+				continue
+			}
 			return false
 		}
 	}


### PR DESCRIPTION
If an empty scope is somehow passed along, it shouldn't be validated
when checking refresh token scope.