### PR TITLE
*: update Go version used to build Dex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ services:
 language: go
 
 go:
-  - 1.5.4
-  - 1.6.2
+  - 1.6.3
   - tip
 
 env:
@@ -40,7 +39,7 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
-    go: '1.6.2'
+    go: '1.6.3'
     condition: "$TRAVIS_PULL_REQUEST = false"
 
 notifications:

--- a/env
+++ b/env
@@ -3,14 +3,14 @@ MAJOR_GOVERSION=$( go version | grep -o 'go1\.[0-9]' || true)
 FULL_GOVERSION=$( go version| grep -o 'go1\.[0-9|\.]*' || true)
 
 # The list of unsupported major go versions.
-UNSUPPORTED=( "go1.0" "go1.1" "go1.2" "go1.3" "go1.4" )
+UNSUPPORTED=( "go1.0" "go1.1" "go1.2" "go1.3" "go1.4" "go1.5" )
 
 # Minor go verisons which have known security vulnerabilities. Refuse to build with these.
-KNOWN_INSECURE=( "go1.5" "go1.5.1" "go1.5.2" )
+KNOWN_INSECURE=( "go1.6" "go1.6.1" "go1.6.2" )
 
 for V in "${UNSUPPORTED[@]}"; do
     if [ "$V" = "$MAJOR_GOVERSION" ]; then
-        echo "dex requires Go version 1.5.3+. Please update your Go version."
+        echo "dex requires Go version 1.6.3+. Please update your Go version."
         exit 2
     fi
 done

--- a/go-docker
+++ b/go-docker
@@ -23,4 +23,4 @@ for VAR in ${DOCKER_LINKS//,/ }; do
 done
 
 echo "running with docker, might take a while to pull the image..."
-docker run $LINKS_STR $ENV_STR --rm -v `pwd`:/go/src/$REPO -w /go/src/$REPO -t golang:1.6.2 $@
+docker run $LINKS_STR $ENV_STR --rm -v `pwd`:/go/src/$REPO -w /go/src/$REPO -t golang:1.6.3 $@


### PR DESCRIPTION
Due to today's security release of Go update Dex to build with the latest version.[0]

Don't know if this requires dropping Go1.5 and older releases of Go1.6 as I can't say that the vulnerability doesn't impact Dex. Going to defer to @gtank.

[0] https://groups.google.com/forum/#!topic/golang-announce/7jZDOQ8f8tM