### PR TITLE
backend: add absolute path to template links

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	texttemplate "text/template"
 	"time"
@@ -63,7 +64,7 @@ func (cfg *ServerConfig) Server() (*Server, error) {
 		return nil, err
 	}
 
-	tpl, err := getTemplates(cfg.IssuerName, cfg.IssuerLogoURL, cfg.EnableRegistration, cfg.TemplateDir)
+	tpl, err := getTemplates(cfg.IssuerName, cfg.IssuerURL, cfg.IssuerLogoURL, cfg.EnableRegistration, cfg.TemplateDir)
 	if err != nil {
 		return nil, err
 	}
@@ -281,8 +282,14 @@ func (cfg *MultiServerConfig) Configure(srv *Server) error {
 	return nil
 }
 
-func getTemplates(issuerName, issuerLogoURL string,
+func getTemplates(issuerName, issuerURL, issuerLogoURL string,
 	enableRegister bool, dir string) (*template.Template, error) {
+	u, err := url.Parse(issuerURL)
+	if err != nil {
+		return nil, err
+	}
+	issuerPath := u.Path
+
 	tpl := template.New("").Funcs(map[string]interface{}{
 		"issuerName": func() string {
 			return issuerName
@@ -292,6 +299,9 @@ func getTemplates(issuerName, issuerLogoURL string,
 		},
 		"enableRegister": func() bool {
 			return enableRegister
+		},
+		"absPath": func(p string) string {
+			return path.Join(issuerPath, p)
 		},
 	})
 

--- a/server/testutil_test.go
+++ b/server/testutil_test.go
@@ -230,7 +230,7 @@ func makeTestFixturesWithOptions(options testFixtureOptions) (*testFixtures, err
 		return nil, err
 	}
 
-	tpl, err := getTemplates("dex",
+	tpl, err := getTemplates("dex", "https://coreos.com",
 		"https://coreos.com/assets/images/brand/coreos-mark-30px.png",
 		true, templatesLocation)
 	if err != nil {

--- a/static/html/ldap-login.html
+++ b/static/html/ldap-login.html
@@ -2,7 +2,7 @@
 
 <div class="panel">
   <h2 class="heading">Log in to Your Account</h2>
-  <form method="post" action="{{.PostURL}}">
+  <form method="post" action="{{.PostURL | absPath }}">
     <div class="form-row">
       LDAP
       <div class="input-desc">
@@ -13,7 +13,7 @@
     <div class="form-row">
       <div class="input-desc">
         <label for="password">Password</label>
-        <span class="subtle-text input-label-right">Forgot? <a href="/send-reset-password?session_key={{ .SessionKey }}">Reset Password</a></span>
+        <span class="subtle-text input-label-right">Forgot? <a href="{{ "/send-reset-password" | absPath }}?session_key={{ .SessionKey }}">Reset Password</a></span>
       </div>
       <input tabindex="2" required id="password" name="password" type="password" class="input-box" placeholder="password"/>
     </div>

--- a/static/html/local-login.html
+++ b/static/html/local-login.html
@@ -2,7 +2,7 @@
 
 <div class="panel">
   <h2 class="heading">Log in to Your Account</h2>
-  <form method="post" action="{{.PostURL}}">
+  <form method="post" action="{{.PostURL | absPath}}">
     <div class="form-row">
       <div class="input-desc">
         <label for="userid">Email Address</label>
@@ -12,7 +12,7 @@
     <div class="form-row">
       <div class="input-desc">
         <label for="password">Password</label>
-        <span class="subtle-text input-label-right">Forgot? <a href="/send-reset-password?session_key={{ .SessionKey }}">Reset Password</a></span>
+        <span class="subtle-text input-label-right">Forgot? <a href="{{ "/send-reset-password" | absPath }}?session_key={{ .SessionKey }}">Reset Password</a></span>
       </div>
       <input tabindex="2" required id="password" name="password" type="password" class="input-box" placeholder="password"/>
     </div>

--- a/static/html/login.html
+++ b/static/html/login.html
@@ -40,7 +40,7 @@
       {{ if .Register }}
         {{ range $c := .Links }}
           <div class="form-row">
-            <a href="{{ $c.URL }}" target="_self">
+            <a href="{{ $c.URL | absPath }}" target="_self">
               <button class="btn btn-provider">
                 <span class="btn-icon btn-icon-{{ $c.ID }}"></span>
                 <span class="btn-text">Use {{ $c.DisplayName }}</span>
@@ -51,7 +51,7 @@
       {{ else }}
         {{ range $c := .Links }}
           <div class="form-row">
-            <a href="{{ $c.URL }}" target="_self">
+            <a href="{{ $c.URL | absPath }}" target="_self">
               <button class="btn btn-provider">
                 <span class="btn-icon btn-icon-{{ $c.ID }}"></span>
                 <span class="btn-text">Log in with {{ $c.DisplayName }}</span>
@@ -68,10 +68,10 @@
 {{ if not .Error }}
   <div class="footer subtle-text">
     {{ if .Register }}
-        Already have an account? <a href="{{ .RegisterOrLoginURL }}">Log in</a>
+        Already have an account? <a href="{{ .RegisterOrLoginURL | absPath }}">Log in</a>
     {{ else }}
       {{ if enableRegister }}
-        Don't have an account yet? <a href="{{ .RegisterOrLoginURL }}">Register</a>
+        Don't have an account yet? <a href="{{ .RegisterOrLoginURL | absPath }}">Register</a>
       {{ end }}
     {{ end }}
   </div>

--- a/static/html/register.html
+++ b/static/html/register.html
@@ -12,7 +12,7 @@
        If you'd like to login with that account, click here:
      </div>
       <div>
-        <a href="{{ .Login }}" target="_self">
+        <a href="{{ .Login | absPath }}" target="_self">
           <button class="btn btn-provider">
             <span class="btn-text">Login</span>
           </button>
@@ -22,7 +22,7 @@
         If you would like to register with a different account, click here:
       </div>
       <div>
-        <a href="{{ .Register }}" target="_self">
+        <a href="{{ .Register | absPath }}" target="_self">
           <button class="btn btn-provider">
             <span class="btn-text">Register</span>
           </button>
@@ -32,7 +32,7 @@
 
   {{ else }}
 
-    <form id="registerForm" method="POST" action="/register">
+  <form id="registerForm" method="POST" action="{{ "/register" | absPath }}">
 
       <div class="form-row">
         <div class="input-desc">

--- a/static/html/send-reset-password.html
+++ b/static/html/send-reset-password.html
@@ -13,7 +13,7 @@
   <h2 class="heading">Reset your password </h2>
   <div class="explain">We will send you an email with a link to reset your password.</div>
 
-  <form id="sendResetPasswordForm" method="POST" action="/send-reset-password">
+  <form id="sendResetPasswordForm" method="POST" action="{{ "/send-reset-password" | absPath }}">
 
     <div class="form-row">
       <div class="input-desc">


### PR DESCRIPTION
fixes: #502

WIP

Add a new template function called `absPath` that converts relative
paths to absolute paths based on the issuerURL. The template function
can be used in templates like:
````html
<a href="{{ .MyRelativePath | absPath }}">
````
or simply:
````html
<a href="{{ absPath }}/myrelativepath">
````