### PR TITLE
server: when registering a user, set user name if OIDC identity contains one

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -416,6 +416,13 @@ func (s *Server) Login(ident oidc.Identity, key string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("getting created user: %v", err)
 		}
+
+		if ses.Identity.Name != "" && ses.Identity.Name != usr.DisplayName {
+			err = s.UserManager.SetDisplayName(usr, ses.Identity.Name)
+			if err != nil {
+				return "", fmt.Errorf("couldn't set display name for user: %v", err)
+			}
+		}
 	} else if err != nil {
 		return "", fmt.Errorf("getting user: %v", err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -358,6 +358,42 @@ func TestServerLoginDisabledUser(t *testing.T) {
 	}
 }
 
+func TestServerLoginDisplayName(t *testing.T) {
+	f, err := makeTestFixtures()
+	if err != nil {
+		t.Fatalf("error making test fixtures: %v", err)
+	}
+
+	sm := f.sessionManager
+	sessionID, err := sm.NewSession(testConnectorIDOpenID, testClientID, "bogus", testRedirectURL, "", false, []string{"openid"})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	key, err := sm.NewSessionKey(sessionID)
+	if err != nil {
+		t.Errorf("new session key: %v", err)
+	}
+
+	f.srv.RegisterOnFirstLogin = true
+
+	ident := oidc.Identity{ID: testUserRemoteID1, Name: "elroy", Email: "elroy@example.com"}
+	_, err = f.srv.Login(ident, key)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	usr, err := f.srv.UserRepo.GetByEmail(nil, ident.Email)
+	if err != nil {
+		t.Fatalf("Couldn't retrieve user we just created: %v", err)
+	}
+
+	if usr.DisplayName != ident.Name {
+		t.Fatalf("User display name (%s) did not match name on identity (%s)",
+			usr.DisplayName, ident.Name)
+	}
+}
+
 func TestServerCodeToken(t *testing.T) {
 	f, err := makeTestFixtures()
 	if err != nil {

--- a/user/manager/manager.go
+++ b/user/manager/manager.go
@@ -120,6 +120,25 @@ func (m *UserManager) Disable(userID string, disabled bool) error {
 	return nil
 }
 
+func (m *UserManager) SetDisplayName(usr user.User, displayName string) error {
+	tx, err := m.begin()
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+
+	usr.DisplayName = displayName
+	if err = m.userRepo.Update(tx, usr); err != nil {
+		return err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // RegisterWithRemoteIdentity creates new user and attaches the given remote identity.
 func (m *UserManager) RegisterWithRemoteIdentity(email string, emailVerified bool, rid user.RemoteIdentity) (string, error) {
 	tx, err := m.begin()


### PR DESCRIPTION
When automatically registering a user from an IP that provides
a `DisplayName`, set it on the created user so that JWT we create
contain a meaningful `name` field.

Added new test and ran existing ones.