### PR TITLE
Fix typo in dexctl parameter

### DIFF
--- a/Documentation/connectors-configuration.md
+++ b/Documentation/connectors-configuration.md
@@ -235,5 +235,5 @@ If the client requests the "groups" scope, the names of all returned entries are
 To set a connectors configuration in dex, put it in some temporary file, then use the dexctl command to upload it to dex:
 
 ```
-dexctl -db-url=$DEX_DB_URL set-connector-configs /tmp/dex_connectors.json
+dexctl --db-url=$DEX_DB_URL set-connector-configs /tmp/dex_connectors.json
 ```


### PR DESCRIPTION
Just a small typo fix in the documentation of the connectors.