### PR TITLE
*: update examples to hold valid client secrets for no-db mode

### DIFF
--- a/Documentation/tls-setup.md
+++ b/Documentation/tls-setup.md
@@ -46,7 +46,7 @@ When establishing connection to the server, we will need to provide the CA file 
 ./bin/example-app \
     --trusted-ca-file=examples/tls-setup/certs/ca.pem \
     --client-id="XXX" \
-    --client-secret="secrete" \
+    --client-secret="c2VjcmV0ZQ==" \
     --redirect-url="http://127.0.0.1:5555/callback" \
     --discovery="https://127.0.0.1:5556" \
     --listen="http://127.0.0.1:5555"

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,7 +34,7 @@ supplying the client information from `./static/fixtures/clients.json` into the 
 ```console
 ./bin/example-app \
 	--client-id=example-app \
-	--client-secret=example-app-secret \
+	--client-secret=eZXhhbXBsZS1jbGktc2VjcmV0 \
 	--discovery=http://127.0.0.1:5556
 ```
 
@@ -54,6 +54,6 @@ The example CLI will start, connect to the Dex instance to gather discovery info
 ```console
 ./bin/example-cli \
 	--client-id example-cli \
-	--client-secret examplie-cli-secret \
+	--client-secret ZXhhbXBsZS1jbGktc2VjcmV0 \
 	--discovery=http://127.0.0.1:5556
 ```


### PR DESCRIPTION
It was noted in #542 that our examples don't hold valid client secrets for no-db mode.

#337 strikes again.
