### PR TITLE
storage: increase the number of bytes randomly generated for IDs

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -30,7 +30,7 @@ var encoding = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567")
 
 // NewID returns a random string which can be used as an ID for objects.
 func NewID() string {
-	buff := make([]byte, 8) // 64 bit random ID.
+	buff := make([]byte, 16) // 128 bit random ID.
 	if _, err := io.ReadFull(rand.Reader, buff); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Because these values are used for OAuth2 codes, refresh tokens,
etc, they shouldn't be guessable. Increase the number of random
bytes from 64 to 128.

cc @gtank 