### PR TITLE
server: allow extra spaces in scopes

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -537,7 +537,7 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request, clie
 
 	scopes := refresh.Scopes
 	if scope != "" {
-		requestedScopes := strings.Split(scope, " ")
+		requestedScopes := strings.Fields(scope)
 		var unauthorizedScopes []string
 
 		for _, s := range requestedScopes {

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -213,7 +213,7 @@ func parseAuthorizationRequest(s storage.Storage, supportedResponseTypes map[str
 		return &authErr{state, redirectURI, typ, fmt.Sprintf(format, a...)}
 	}
 
-	scopes := strings.Split(r.Form.Get("scope"), " ")
+	scopes := strings.Fields(r.Form.Get("scope"))
 
 	var (
 		unrecognized  []string


### PR DESCRIPTION
go-oidc sends an extra space before the list of scopes. This is bad
but we have to support it, so we'll be more lenient and ignore
duplicated whitespace.