### PR TITLE
*: expand environment variables in config

### DIFF
--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
@@ -44,6 +45,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("read config file %s: %v", configFile, err)
 	}
+	configData = []byte(os.ExpandEnv(string(configData)))
 
 	var c Config
 	if err := yaml.Unmarshal(configData, &c); err != nil {

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 
 	"golang.org/x/net/context"
@@ -32,8 +31,8 @@ func (c *Config) Open() (connector.Connector, error) {
 		redirectURI: c.RedirectURI,
 		org:         c.Org,
 		oauth2Config: &oauth2.Config{
-			ClientID:     os.ExpandEnv(c.ClientID),
-			ClientSecret: os.ExpandEnv(c.ClientSecret),
+			ClientID:     c.ClientID,
+			ClientSecret: c.ClientSecret,
 			Endpoint:     github.Endpoint,
 			Scopes: []string{
 				"user:email", // View user's email

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/ericchiang/oidc"
 	"golang.org/x/net/context"
@@ -42,12 +41,12 @@ func (c *Config) Open() (conn connector.Connector, err error) {
 		scopes = append(scopes, "profile", "email")
 	}
 
-	clientID := os.ExpandEnv(c.ClientID)
+	clientID := c.ClientID
 	return &oidcConnector{
 		redirectURI: c.RedirectURI,
 		oauth2Config: &oauth2.Config{
 			ClientID:     clientID,
-			ClientSecret: os.ExpandEnv(c.ClientSecret),
+			ClientSecret: c.ClientSecret,
 			Endpoint:     provider.Endpoint(),
 			Scopes:       scopes,
 			RedirectURL:  c.RedirectURI,

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -37,6 +37,15 @@ connectors:
 - type: mockCallback
   id: mock
   name: Example
+# - type: oidc
+#   id: google
+#   name: Google
+#   config:
+#     issuer: https://accounts.google.com
+#     #  Config values starting with a "$" will read from the environment.
+#     clientID: $GOOGLE_CLIENT_ID
+#     clientSecret: $GOOGLE_CLIENT_SECRET
+#     redirectURI: http://127.0.0.1:5556/dex/callback/google
 
 # Let dex keep a list of passwords which can be used to login the user
 enablePasswordDB: true


### PR DESCRIPTION
Allow users to define config values which are read form environemnt
variables. Helpful for sensitive variables such as OAuth2 client IDs
or LDAP credentials.