### PR TITLE
storage/kubernetes: don't automatically print errors on bad HTTP status codes

### DIFF
--- a/storage/kubernetes/client.go
+++ b/storage/kubernetes/client.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -95,18 +94,17 @@ func checkHTTPErr(r *http.Response, validStatusCodes ...int) error {
 		return fmt.Errorf("read response body: %v", err)
 	}
 
+	// Check this case after we read the body so the connection can be reused.
+	if r.StatusCode == http.StatusNotFound {
+		return storage.ErrNotFound
+	}
+
 	var url, method string
 	if r.Request != nil {
 		method = r.Request.Method
 		url = r.Request.URL.String()
 	}
-	err = &httpErr{method, url, r.StatusCode, body}
-	log.Printf("%s", err)
-
-	if r.StatusCode == http.StatusNotFound {
-		return storage.ErrNotFound
-	}
-	return err
+	return &httpErr{method, url, r.StatusCode, body}
 }
 
 // Close the response body. The initial request is drained so the connection can


### PR DESCRIPTION
These status codes spam the error logs for events like key rotation
and third party resource creation. In these cases "bad" status codes
are expected and shouldn't be automatically printed.