### PR TITLE
server/handlers: fix Cache-Control header

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -84,7 +84,7 @@ func (s *Server) handlePublicKeys(w http.ResponseWriter, r *http.Request) {
 		maxAge = time.Minute * 2
 	}
 
-	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, must-revalidate", maxAge))
+	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, must-revalidate", int(maxAge.Seconds())))
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
 	w.Write(data)


### PR DESCRIPTION
fixes: #636

This commit addresses a problem where the `max-age` value is being set
in nanoseconds as opposed to seconds, as required by the specification.