### PR TITLE
scripts: fix get-protoc script to work directly after a clean

### DIFF
--- a/scripts/get-protoc
+++ b/scripts/get-protoc
@@ -17,6 +17,8 @@ if [ "$OS" = "darwin" ]; then
   OS="osx"
 fi
 
+mkdir -p bin
+
 # TODO(ericchiang): Architectures other than amd64?
 ZIP="protoc-${VERSION}-${OS}-x86_64.zip"
 URL="https://github.com/google/protobuf/releases/download/v${VERSION}/${ZIP}"


### PR DESCRIPTION
Right now `make grpc` only works if a user hasn't run a `make clean`.
Fix this.