### PR TITLE
storage/kubernetes: allow arbitrary client IDs

### DIFF
--- a/storage/kubernetes/client_test.go
+++ b/storage/kubernetes/client_test.go
@@ -1,6 +1,33 @@
 package kubernetes
 
-import "testing"
+import (
+	"hash"
+	"hash/fnv"
+	"sync"
+	"testing"
+)
+
+// This test does not have an explicit error condition but is used
+// with the race detector to detect the safety of idToName.
+func TestIDToName(t *testing.T) {
+	n := 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+	c := make(chan struct{})
+
+	h := func() hash.Hash { return fnv.New64() }
+
+	for i := 0; i < n; i++ {
+		go func() {
+			<-c
+			name := idToName("foo", h)
+			_ = name
+			wg.Done()
+		}()
+	}
+	close(c)
+	wg.Wait()
+}
 
 func TestNamespaceFromServiceAccountJWT(t *testing.T) {
 	namespace, err := namespaceFromServiceAccountJWT(serviceAccountToken)


### PR DESCRIPTION
Use a hash algorithm to match client IDs to Kubernetes object names.
Because cryptographic hash algorithms produce sums larger than a
Kubernetes name can fit, a non-cryptographic hash is used instead.
Hash collisions are checked and result in errors.

Closes #631