### PR TITLE
*: don't error out if a username doesn't exist in the backing connector

### DIFF
--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -310,7 +310,9 @@ func (c *ldapConnector) Login(username, password string) (ident connector.Identi
 
 		switch n := len(resp.Entries); n {
 		case 0:
-			return fmt.Errorf("ldap: no results returned for filter: %q", filter)
+			log.Printf("ldap: no results returned for filter: %q", filter)
+			incorrectPass = true
+			return nil
 		case 1:
 		default:
 			return fmt.Errorf("ldap: filter returned multiple (%d) results: %q", n, filter)
@@ -334,6 +336,9 @@ func (c *ldapConnector) Login(username, password string) (ident connector.Identi
 	})
 	if err != nil {
 		return connector.Identity{}, false, err
+	}
+	if incorrectPass {
+		return connector.Identity{}, false, nil
 	}
 
 	// Encode entry for follow up requests such as the groups query and
@@ -364,7 +369,7 @@ func (c *ldapConnector) Login(username, password string) (ident connector.Identi
 		return connector.Identity{}, false, err
 	}
 
-	return ident, !incorrectPass, nil
+	return ident, true, nil
 }
 
 func (c *ldapConnector) Groups(ident connector.Identity) ([]string, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -218,8 +218,9 @@ func (db passwordDB) Login(email, password string) (connector.Identity, bool, er
 	if err != nil {
 		if err != storage.ErrNotFound {
 			log.Printf("get password: %v", err)
+			return connector.Identity{}, false, err
 		}
-		return connector.Identity{}, false, err
+		return connector.Identity{}, false, nil
 	}
 	if err := bcrypt.CompareHashAndPassword(p.Hash, []byte(password)); err != nil {
 		return connector.Identity{}, false, nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -657,10 +657,10 @@ func TestPasswordDB(t *testing.T) {
 			},
 		},
 		{
-			name:     "unknown user",
-			username: "john@example.com",
-			password: pw,
-			wantErr:  true,
+			name:        "unknown user",
+			username:    "john@example.com",
+			password:    pw,
+			wantInvalid: true,
 		},
 		{
 			name:        "invalid password",


### PR DESCRIPTION
Instead of throwing a 500 error if a user enters an invalid name,
display the same text box as if the user had entered the wrong
password.

NOTE: An invalid username now returns much quicker than an invalid
password. Consider adding an arbitrary sleep in the future if we
care about masking which was invalid.

cc @rithujohn191 @kans @dghubble 

closes #656