### PR TITLE
cmd/dex: expose IDTokensValidFor and RotateKeysAfter server options in config

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Web        Web         `json:"web"`
 	OAuth2     OAuth2      `json:"oauth2"`
 	GRPC       GRPC        `json:"grpc"`
+	Expiry     Expiry      `json:"expiry"`
 
 	Templates server.TemplateConfig `json:"templates"`
 
@@ -209,4 +210,13 @@ func (c *Connector) UnmarshalJSON(b []byte) error {
 		Config: connConfig,
 	}
 	return nil
+}
+
+// Expiry holds configuration for the validity period of components.
+type Expiry struct {
+	// SigningKeys defines the duration of time after which the SigningKeys will be rotated.
+	SigningKeys string `json:"signingKeys"`
+
+	// IdTokens defines the duration of time for which the IdTokens will be valid.
+	IDTokens string `json:"idTokens"`
 }

--- a/cmd/dex/config_test.go
+++ b/cmd/dex/config_test.go
@@ -56,6 +56,10 @@ staticPasswords:
   hash: "JDJhJDEwJDMzRU1UMGNWWVZsUHk2V0FNQ0xzY2VMWWpXaHVIcGJ6NXl1Wnh1L0dBRmowM0o5THl0anV5"
   username: "foo"
   userID: "41331323-6f44-45e6-b3b9-2c4b60c02be5"
+
+expiry:
+  signingKeys: "6h"
+  idTokens: "24h"
 `)
 
 	want := Config{
@@ -112,6 +116,10 @@ staticPasswords:
 				Username: "foo",
 				UserID:   "41331323-6f44-45e6-b3b9-2c4b60c02be5",
 			},
+		},
+		Expiry: Expiry{
+			SigningKeys: "6h",
+			IDTokens:    "24h",
 		},
 	}
 

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
@@ -151,6 +152,20 @@ func serve(cmd *cobra.Command, args []string) error {
 		Storage:                s,
 		TemplateConfig:         c.Templates,
 		EnablePasswordDB:       c.EnablePasswordDB,
+	}
+	if c.Expiry.SigningKeys != "" {
+		signingKeys, err := time.ParseDuration(c.Expiry.SigningKeys)
+		if err != nil {
+			return fmt.Errorf("parsing signingKeys expiry: %v", err)
+		}
+		serverConfig.RotateKeysAfter = signingKeys
+	}
+	if c.Expiry.IDTokens != "" {
+		idTokens, err := time.ParseDuration(c.Expiry.IDTokens)
+		if err != nil {
+			return fmt.Errorf("parsing idTokens expiry: %v", err)
+		}
+		serverConfig.IDTokensValidFor = idTokens
 	}
 
 	serv, err := server.NewServer(context.Background(), serverConfig)

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -62,3 +62,7 @@ staticPasswords:
   username: "admin"
   userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
 
+# Uncomment this block to enable configuration for the expiration time durations.
+# expiry:
+#   signingKeys: "6h"
+#   idTokens: "24h"


### PR DESCRIPTION
closes #660.

@ericchiang 