### PR TITLE
*: travis tests and build scripts should use Go 1.7.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7.1
+  - 1.7.3
 
 services:
   - postgresql

--- a/scripts/rkt-build
+++ b/scripts/rkt-build
@@ -8,6 +8,6 @@ sudo rkt run \
     --dns=8.8.8.8 \
     --net=host \
     --insecure-options=image \
-    docker://golang:1.7.1-alpine \
+    docker://golang:1.7.3-alpine \
     --exec=/bin/sh -- -x -c \
     'apk add --no-cache --update alpine-sdk && cd /go/src/github.com/coreos/dex && make release-binary'


### PR DESCRIPTION
closes #663.

@ericchiang 