### PR TITLE
*: switch to github.com/ghodss/yaml for more consistent YAML parsing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,4 +48,3 @@ Backend
 
 - [ ] Improve logging, possibly switch to logrus
 - [ ] Standardize OAuth2 error handling
-- [ ] Switch to github.com/ghodss/yaml for []byte to base64 string logic

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"encoding/base64"
+	"encoding/json"
 	"fmt"
 
 	"github.com/coreos/dex/connector"
@@ -18,129 +18,58 @@ import (
 
 // Config is the config format for the main application.
 type Config struct {
-	Issuer     string      `yaml:"issuer"`
-	Storage    Storage     `yaml:"storage"`
-	Connectors []Connector `yaml:"connectors"`
-	Web        Web         `yaml:"web"`
-	OAuth2     OAuth2      `yaml:"oauth2"`
-	GRPC       GRPC        `yaml:"grpc"`
+	Issuer     string      `json:"issuer"`
+	Storage    Storage     `json:"storage"`
+	Connectors []Connector `json:"connectors"`
+	Web        Web         `json:"web"`
+	OAuth2     OAuth2      `json:"oauth2"`
+	GRPC       GRPC        `json:"grpc"`
 
-	Templates server.TemplateConfig `yaml:"templates"`
+	Templates server.TemplateConfig `json:"templates"`
 
 	// StaticClients cause the server to use this list of clients rather than
 	// querying the storage. Write operations, like creating a client, will fail.
-	StaticClients []storage.Client `yaml:"staticClients"`
+	StaticClients []storage.Client `json:"staticClients"`
 
 	// If enabled, the server will maintain a list of passwords which can be used
 	// to identify a user.
-	EnablePasswordDB bool `yaml:"enablePasswordDB"`
+	EnablePasswordDB bool `json:"enablePasswordDB"`
 
 	// StaticPasswords cause the server use this list of passwords rather than
 	// querying the storage. Cannot be specified without enabling a passwords
 	// database.
-	//
-	// The "password" type is identical to the storage.Password type, but does
-	// unmarshaling into []byte correctly.
-	StaticPasswords []password `yaml:"staticPasswords"`
-}
-
-type password struct {
-	Email    string `yaml:"email"`
-	Username string `yaml:"username"`
-	UserID   string `yaml:"userID"`
-
-	// Because our YAML parser doesn't base64, we have to do it ourselves.
-	//
-	// TODO(ericchiang): switch to github.com/ghodss/yaml
-	Hash string `yaml:"hash"`
-}
-
-// decode the hash appropriately and convert to the storage passwords.
-func (p password) toPassword() (storage.Password, error) {
-	hash, err := base64.StdEncoding.DecodeString(p.Hash)
-	if err != nil {
-		return storage.Password{}, fmt.Errorf("decoding hash: %v", err)
-	}
-	return storage.Password{
-		Email:    p.Email,
-		Username: p.Username,
-		UserID:   p.UserID,
-		Hash:     hash,
-	}, nil
+	StaticPasswords []storage.Password `json:"staticPasswords"`
 }
 
 // OAuth2 describes enabled OAuth2 extensions.
 type OAuth2 struct {
-	ResponseTypes []string `yaml:"responseTypes"`
+	ResponseTypes []string `json:"responseTypes"`
 	// If specified, do not prompt the user to approve client authorization. The
 	// act of logging in implies authorization.
-	SkipApprovalScreen bool `yaml:"skipApprovalScreen"`
+	SkipApprovalScreen bool `json:"skipApprovalScreen"`
 }
 
 // Web is the config format for the HTTP server.
 type Web struct {
-	HTTP    string `yaml:"http"`
-	HTTPS   string `yaml:"https"`
-	TLSCert string `yaml:"tlsCert"`
-	TLSKey  string `yaml:"tlsKey"`
+	HTTP    string `json:"http"`
+	HTTPS   string `json:"https"`
+	TLSCert string `json:"tlsCert"`
+	TLSKey  string `json:"tlsKey"`
 }
 
 // GRPC is the config for the gRPC API.
 type GRPC struct {
 	// The port to listen on.
-	Addr        string `yaml:"addr"`
-	TLSCert     string `yaml:"tlsCert"`
-	TLSKey      string `yaml:"tlsKey"`
-	TLSClientCA string `yaml:"tlsClientCA"`
+	Addr        string `json:"addr"`
+	TLSCert     string `json:"tlsCert"`
+	TLSKey      string `json:"tlsKey"`
+	TLSClientCA string `json:"tlsClientCA"`
 }
 
 // Storage holds app's storage configuration.
 type Storage struct {
-	Type   string        `yaml:"type"`
-	Config StorageConfig `yaml:"config"`
-}
-
-// UnmarshalYAML allows Storage to unmarshal its config field dynamically
-// depending on the type of storage.
-func (s *Storage) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var storageMeta struct {
-		Type string `yaml:"type"`
-	}
-	if err := unmarshal(&storageMeta); err != nil {
-		return err
-	}
-	s.Type = storageMeta.Type
-	// TODO(ericchiang): replace this with a registration process.
-	var err error
-	switch storageMeta.Type {
-	case "kubernetes":
-		var config struct {
-			Config kubernetes.Config `yaml:"config"`
-		}
-		err = unmarshal(&config)
-		s.Config = &config.Config
-	case "memory":
-		var config struct {
-			Config memory.Config `yaml:"config"`
-		}
-		err = unmarshal(&config)
-		s.Config = &config.Config
-	case "sqlite3":
-		var config struct {
-			Config sql.SQLite3 `yaml:"config"`
-		}
-		err = unmarshal(&config)
-		s.Config = &config.Config
-	case "postgres":
-		var config struct {
-			Config sql.Postgres `yaml:"config"`
-		}
-		err = unmarshal(&config)
-		s.Config = &config.Config
-	default:
-		return fmt.Errorf("unknown storage type %q", storageMeta.Type)
-	}
-	return err
+	Type   string        `json:"type"`
+	Config StorageConfig `json:"config"`
 }
 
 // StorageConfig is a configuration that can create a storage.
@@ -148,14 +77,49 @@ type StorageConfig interface {
 	Open() (storage.Storage, error)
 }
 
+var storages = map[string]func() StorageConfig{
+	"kubernetes": func() StorageConfig { return new(kubernetes.Config) },
+	"memory":     func() StorageConfig { return new(memory.Config) },
+	"sqlite3":    func() StorageConfig { return new(sql.SQLite3) },
+	"postgres":   func() StorageConfig { return new(sql.Postgres) },
+}
+
+// UnmarshalJSON allows Storage to implement the unmarshaler interface to
+// dynamically determine the type of the storage config.
+func (s *Storage) UnmarshalJSON(b []byte) error {
+	var store struct {
+		Type   string          `json:"type"`
+		Config json.RawMessage `json:"config"`
+	}
+	if err := json.Unmarshal(b, &store); err != nil {
+		return fmt.Errorf("parse storage: %v", err)
+	}
+	f, ok := storages[store.Type]
+	if !ok {
+		return fmt.Errorf("unknown storage type %q", store.Type)
+	}
+
+	storageConfig := f()
+	if len(store.Config) != 0 {
+		if err := json.Unmarshal([]byte(store.Config), storageConfig); err != nil {
+			return fmt.Errorf("parse storace config: %v", err)
+		}
+	}
+	*s = Storage{
+		Type:   store.Type,
+		Config: storageConfig,
+	}
+	return nil
+}
+
 // Connector is a magical type that can unmarshal YAML dynamically. The
 // Type field determines the connector type, which is then customized for Config.
 type Connector struct {
-	Type string `yaml:"type"`
-	Name string `yaml:"name"`
-	ID   string `yaml:"id"`
+	Type string `json:"type"`
+	Name string `json:"name"`
+	ID   string `json:"id"`
 
-	Config ConnectorConfig `yaml:"config"`
+	Config ConnectorConfig `json:"config"`
 }
 
 // ConnectorConfig is a configuration that can open a connector.
@@ -163,55 +127,43 @@ type ConnectorConfig interface {
 	Open() (connector.Connector, error)
 }
 
-// UnmarshalYAML allows Connector to unmarshal its config field dynamically
-// depending on the type of connector.
-func (c *Connector) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var connectorMetadata struct {
-		Type string `yaml:"type"`
-		Name string `yaml:"name"`
-		ID   string `yaml:"id"`
-	}
-	if err := unmarshal(&connectorMetadata); err != nil {
-		return err
-	}
-	c.Type = connectorMetadata.Type
-	c.Name = connectorMetadata.Name
-	c.ID = connectorMetadata.ID
+var connectors = map[string]func() ConnectorConfig{
+	"mockCallback": func() ConnectorConfig { return new(mock.CallbackConfig) },
+	"mockPassword": func() ConnectorConfig { return new(mock.PasswordConfig) },
+	"ldap":         func() ConnectorConfig { return new(ldap.Config) },
+	"github":       func() ConnectorConfig { return new(github.Config) },
+	"oidc":         func() ConnectorConfig { return new(oidc.Config) },
+}
 
-	var err error
-	switch c.Type {
-	case "mockCallback":
-		var config struct {
-			Config mock.CallbackConfig `yaml:"config"`
-		}
-		err = unmarshal(&config)
-		c.Config = &config.Config
-	case "mockPassword":
-		var config struct {
-			Config mock.PasswordConfig `yaml:"config"`
-		}
-		err = unmarshal(&config)
-		c.Config = &config.Config
-	case "ldap":
-		var config struct {
-			Config ldap.Config `yaml:"config"`
-		}
-		err = unmarshal(&config)
-		c.Config = &config.Config
-	case "github":
-		var config struct {
-			Config github.Config `yaml:"config"`
-		}
-		err = unmarshal(&config)
-		c.Config = &config.Config
-	case "oidc":
-		var config struct {
-			Config oidc.Config `yaml:"config"`
-		}
-		err = unmarshal(&config)
-		c.Config = &config.Config
-	default:
-		return fmt.Errorf("unknown connector type %q", c.Type)
+// UnmarshalJSON allows Connector to implement the unmarshaler interface to
+// dynamically determine the type of the connector config.
+func (c *Connector) UnmarshalJSON(b []byte) error {
+	var conn struct {
+		Type string `json:"type"`
+		Name string `json:"name"`
+		ID   string `json:"id"`
+
+		Config json.RawMessage `json:"config"`
 	}
-	return err
+	if err := json.Unmarshal(b, &conn); err != nil {
+		return fmt.Errorf("parse connector: %v", err)
+	}
+	f, ok := connectors[conn.Type]
+	if !ok {
+		return fmt.Errorf("unknown connector type %q", conn.Type)
+	}
+
+	connConfig := f()
+	if len(conn.Config) != 0 {
+		if err := json.Unmarshal([]byte(conn.Config), connConfig); err != nil {
+			return fmt.Errorf("parse connector config: %v", err)
+		}
+	}
+	*c = Connector{
+		Type:   conn.Type,
+		Name:   conn.Type,
+		ID:     conn.ID,
+		Config: connConfig,
+	}
+	return nil
 }

--- a/cmd/dex/config_test.go
+++ b/cmd/dex/config_test.go
@@ -3,37 +3,124 @@ package main
 import (
 	"testing"
 
+	"github.com/coreos/dex/connector/mock"
+	"github.com/coreos/dex/connector/oidc"
 	"github.com/coreos/dex/storage"
+	"github.com/coreos/dex/storage/sql"
+	"github.com/ghodss/yaml"
 	"github.com/kylelemons/godebug/pretty"
-
-	yaml "gopkg.in/yaml.v2"
 )
 
-func TestUnmarshalClients(t *testing.T) {
-	data := `staticClients:
+var _ = yaml.YAMLToJSON
+
+func TestUnmarshalConfig(t *testing.T) {
+	rawConfig := []byte(`
+issuer: http://127.0.0.1:5556/dex
+storage:
+  type: sqlite3
+  config:
+    file: examples/dex.db
+
+web:
+  http: 127.0.0.1:5556
+staticClients:
 - id: example-app
   redirectURIs:
   - 'http://127.0.0.1:5555/callback'
   name: 'Example App'
   secret: ZXhhbXBsZS1hcHAtc2VjcmV0
-`
-	var c Config
-	if err := yaml.Unmarshal([]byte(data), &c); err != nil {
-		t.Fatal(err)
-	}
 
-	wantClients := []storage.Client{
-		{
-			ID:     "example-app",
-			Name:   "Example App",
-			Secret: "ZXhhbXBsZS1hcHAtc2VjcmV0",
-			RedirectURIs: []string{
-				"http://127.0.0.1:5555/callback",
+connectors:
+- type: mockCallback
+  id: mock
+  name: Example
+- type: oidc
+  id: google
+  name: Google
+  config:
+    issuer: https://accounts.google.com
+    #  Config values starting with a "$" will read from the environment.
+    clientID: $GOOGLE_CLIENT_ID
+    clientSecret: $GOOGLE_CLIENT_SECRET
+    redirectURI: http://127.0.0.1:5556/dex/callback/google
+
+enablePasswordDB: true
+staticPasswords:
+- email: "admin@example.com"
+  # bcrypt hash of the string "password"
+  hash: "$2a$10$33EMT0cVYVlPy6WAMCLsceLYjWhuHpbz5yuZxu/GAFj03J9Lytjuy"
+  username: "admin"
+  userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+- email: "foo@example.com"  
+  # base64'd value of the same bcrypt hash above. We want to be able to parse both of these
+  hash: "JDJhJDEwJDMzRU1UMGNWWVZsUHk2V0FNQ0xzY2VMWWpXaHVIcGJ6NXl1Wnh1L0dBRmowM0o5THl0anV5"
+  username: "foo"
+  userID: "41331323-6f44-45e6-b3b9-2c4b60c02be5"
+`)
+
+	want := Config{
+		Issuer: "http://127.0.0.1:5556/dex",
+		Storage: Storage{
+			Type: "sqlite3",
+			Config: &sql.SQLite3{
+				File: "examples/dex.db",
+			},
+		},
+		Web: Web{
+			HTTP: "127.0.0.1:5556",
+		},
+		StaticClients: []storage.Client{
+			{
+				ID:     "example-app",
+				Secret: "ZXhhbXBsZS1hcHAtc2VjcmV0",
+				Name:   "Example App",
+				RedirectURIs: []string{
+					"http://127.0.0.1:5555/callback",
+				},
+			},
+		},
+		Connectors: []Connector{
+			{
+				Type:   "mockCallback",
+				ID:     "mock",
+				Name:   "Example",
+				Config: &mock.CallbackConfig{},
+			},
+			{
+				Type: "oidc",
+				ID:   "google",
+				Name: "Google",
+				Config: &oidc.Config{
+					Issuer:       "https://accounts.google.com",
+					ClientID:     "$GOOGLE_CLIENT_ID",
+					ClientSecret: "$GOOGLE_CLIENT_SECRET",
+					RedirectURI:  "http://127.0.0.1:5556/dex/callback/google",
+				},
+			},
+		},
+		EnablePasswordDB: true,
+		StaticPasswords: []password{
+			{
+				Email:    "admin@example.com",
+				Hash:     []byte("$2a$10$33EMT0cVYVlPy6WAMCLsceLYjWhuHpbz5yuZxu/GAFj03J9Lytjuy"),
+				Username: "admin",
+				UserID:   "08a8684b-db88-4b73-90a9-3cd1661f5466",
+			},
+			{
+				Email:    "foo@example.com",
+				Hash:     []byte("$2a$10$33EMT0cVYVlPy6WAMCLsceLYjWhuHpbz5yuZxu/GAFj03J9Lytjuy"),
+				Username: "foo",
+				UserID:   "41331323-6f44-45e6-b3b9-2c4b60c02be5",
 			},
 		},
 	}
 
-	if diff := pretty.Compare(wantClients, c.StaticClients); diff != "" {
-		t.Errorf("did not get expected clients: %s", diff)
+	var c Config
+	if err := yaml.Unmarshal(rawConfig, &c); err != nil {
+		t.Fatalf("failed to decode config: %v", err)
 	}
+	if diff := pretty.Compare(c, want); diff != "" {
+		t.Errorf("got!=want: %s", diff)
+	}
+
 }

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -136,7 +136,11 @@ func serve(cmd *cobra.Command, args []string) error {
 		s = storage.WithStaticClients(s, c.StaticClients)
 	}
 	if len(c.StaticPasswords) > 0 {
-		s = storage.WithStaticPasswords(s, c.StaticPasswords)
+		passwords := make([]storage.Password, len(c.StaticPasswords))
+		for i, p := range c.StaticPasswords {
+			passwords[i] = storage.Password(p)
+		}
+		s = storage.WithStaticPasswords(s, passwords)
 	}
 
 	serverConfig := server.Config{

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -11,11 +11,11 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	yaml "gopkg.in/yaml.v2"
 
 	"github.com/coreos/dex/api"
 	"github.com/coreos/dex/server"
@@ -136,13 +136,7 @@ func serve(cmd *cobra.Command, args []string) error {
 		s = storage.WithStaticClients(s, c.StaticClients)
 	}
 	if len(c.StaticPasswords) > 0 {
-		p := make([]storage.Password, len(c.StaticPasswords))
-		for i, pw := range c.StaticPasswords {
-			if p[i], err = pw.toPassword(); err != nil {
-				return err
-			}
-		}
-		s = storage.WithStaticPasswords(s, p)
+		s = storage.WithStaticPasswords(s, c.StaticPasswords)
 	}
 
 	serverConfig := server.Config{

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -19,10 +19,10 @@ const baseURL = "https://api.github.com"
 
 // Config holds configuration options for github logins.
 type Config struct {
-	ClientID     string `yaml:"clientID"`
-	ClientSecret string `yaml:"clientSecret"`
-	RedirectURI  string `yaml:"redirectURI"`
-	Org          string `yaml:"org"`
+	ClientID     string `json:"clientID"`
+	ClientSecret string `json:"clientSecret"`
+	RedirectURI  string `json:"redirectURI"`
+	Org          string `json:"org"`
 }
 
 // Open returns a strategy for logging in through GitHub.

--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -53,52 +53,52 @@ import (
 type Config struct {
 	// The host and optional port of the LDAP server. If port isn't supplied, it will be
 	// guessed based on the TLS configuration. 389 or 636.
-	Host string `yaml:"host"`
+	Host string `json:"host"`
 
 	// Required if LDAP host does not use TLS.
-	InsecureNoSSL bool `yaml:"insecureNoSSL"`
+	InsecureNoSSL bool `json:"insecureNoSSL"`
 
 	// Path to a trusted root certificate file.
-	RootCA string `yaml:"rootCA"`
+	RootCA string `json:"rootCA"`
 
 	// BindDN and BindPW for an application service account. The connector uses these
 	// credentials to search for users and groups.
-	BindDN string `yaml:"bindDN"`
-	BindPW string `yaml:"bindPW"`
+	BindDN string `json:"bindDN"`
+	BindPW string `json:"bindPW"`
 
 	// User entry search configuration.
 	UserSearch struct {
 		// BsaeDN to start the search from. For example "cn=users,dc=example,dc=com"
-		BaseDN string `yaml:"baseDN"`
+		BaseDN string `json:"baseDN"`
 
 		// Optional filter to apply when searching the directory. For example "(objectClass=person)"
-		Filter string `yaml:"filter"`
+		Filter string `json:"filter"`
 
 		// Attribute to match against the inputted username. This will be translated and combined
 		// with the other filter as "(<attr>=<username>)".
-		Username string `yaml:"username"`
+		Username string `json:"username"`
 
 		// Can either be:
 		// * "sub" - search the whole sub tree
 		// * "one" - only search one level
-		Scope string `yaml:"scope"`
+		Scope string `json:"scope"`
 
 		// A mapping of attributes on the user entry to claims.
-		IDAttr    string `yaml:"idAttr"`    // Defaults to "uid"
-		EmailAttr string `yaml:"emailAttr"` // Defaults to "mail"
-		NameAttr  string `yaml:"nameAttr"`  // No default.
+		IDAttr    string `json:"idAttr"`    // Defaults to "uid"
+		EmailAttr string `json:"emailAttr"` // Defaults to "mail"
+		NameAttr  string `json:"nameAttr"`  // No default.
 
-	} `yaml:"userSearch"`
+	} `json:"userSearch"`
 
 	// Group search configuration.
 	GroupSearch struct {
 		// BsaeDN to start the search from. For example "cn=groups,dc=example,dc=com"
-		BaseDN string `yaml:"baseDN"`
+		BaseDN string `json:"baseDN"`
 
 		// Optional filter to apply when searching the directory. For example "(objectClass=posixGroup)"
-		Filter string `yaml:"filter"`
+		Filter string `json:"filter"`
 
-		Scope string `yaml:"scope"` // Defaults to "sub"
+		Scope string `json:"scope"` // Defaults to "sub"
 
 		// These two fields are use to match a user to a group.
 		//
@@ -108,12 +108,12 @@ type Config struct {
 		//
 		//   (<groupAttr>=<userAttr value>)
 		//
-		UserAttr  string `yaml:"userAttr"`
-		GroupAttr string `yaml:"groupAttr"`
+		UserAttr  string `json:"userAttr"`
+		GroupAttr string `json:"groupAttr"`
 
 		// The attribute of the group that represents its name.
-		NameAttr string `yaml:"nameAttr"`
-	} `yaml:"groupSearch"`
+		NameAttr string `json:"nameAttr"`
+	} `json:"groupSearch"`
 }
 
 func parseScope(s string) (int, bool) {

--- a/connector/mock/connectortest.go
+++ b/connector/mock/connectortest.go
@@ -69,8 +69,8 @@ func (c *CallbackConfig) Open() (connector.Connector, error) {
 // PasswordConfig holds the configuration for a mock connector which prompts for the supplied
 // username and password.
 type PasswordConfig struct {
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
+	Username string `json:"username"`
+	Password string `json:"password"`
 }
 
 // Open returns an authentication strategy which prompts for a predefined username and password.

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -15,12 +15,12 @@ import (
 
 // Config holds configuration options for OpenID Connect logins.
 type Config struct {
-	Issuer       string `yaml:"issuer"`
-	ClientID     string `yaml:"clientID"`
-	ClientSecret string `yaml:"clientSecret"`
-	RedirectURI  string `yaml:"redirectURI"`
+	Issuer       string `json:"issuer"`
+	ClientID     string `json:"clientID"`
+	ClientSecret string `json:"clientSecret"`
+	RedirectURI  string `json:"redirectURI"`
 
-	Scopes []string `yaml:"scopes"` // defaults to "profile" and "email"
+	Scopes []string `json:"scopes"` // defaults to "profile" and "email"
 }
 
 // Open returns a connector which can be used to login users through an upstream

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -58,7 +58,7 @@ enablePasswordDB: true
 staticPasswords:
 - email: "admin@example.com"
   # bcrypt hash of the string "password"
-  hash: "JDJhJDE0JDh4TnlVZ3pzSmVuQm4ySlRPT2QvbmVGcUlnQzF4TEFVRFA3VlpTVzhDNWlkLnFPcmNlYUJX"
+  hash: "$2a$10$33EMT0cVYVlPy6WAMCLsceLYjWhuHpbz5yuZxu/GAFj03J9Lytjuy"
   username: "admin"
   userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a813cbca07393d7cbe35d411cdef588afac7a3bab8a287ffe7b9587516ef5898
-updated: 2016-10-23T20:51:55.313818678-07:00
+hash: bc7fa6bbfddcb39710064a9d6dab090d49bd88486571cae12c68c4b70093e716
+updated: 2016-11-03T14:31:37.323302694-07:00
 imports:
 - name: github.com/cockroachdb/cockroach-go
   version: 31611c0501c812f437d4861d87d117053967c955
@@ -7,6 +7,8 @@ imports:
   - crdb
 - name: github.com/ericchiang/oidc
   version: 1907f0e61549f9081f26bdf269f11603496c9dee
+- name: github.com/ghodss/yaml
+  version: bea76d6a4713e18b7f5321a2b020738552def3ea
 - name: github.com/go-sql-driver/mysql
   version: 0b58b37b664c21f3010e836f1b931e1d0b0b0685
 - name: github.com/golang/protobuf

--- a/glide.yaml
+++ b/glide.yaml
@@ -32,6 +32,8 @@ import:
   - lex/httplex
   - trace
 
+- package: github.com/ghodss/yaml
+  version: bea76d6a4713e18b7f5321a2b020738552def3ea
 - package: gopkg.in/yaml.v2
   version: a83829b6f1293c91addabc89d0571c246397bbf4
 

--- a/storage/kubernetes/client.go
+++ b/storage/kubernetes/client.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/gtank/cryptopasta"
 	"golang.org/x/net/context"
-	yaml "gopkg.in/yaml.v2"
 
 	"github.com/coreos/dex/storage"
 	"github.com/coreos/dex/storage/kubernetes/k8sapi"

--- a/storage/kubernetes/k8sapi/client.go
+++ b/storage/kubernetes/k8sapi/client.go
@@ -23,124 +23,124 @@ package k8sapi
 type Config struct {
 	// Legacy field from pkg/api/types.go TypeMeta.
 	// TODO(jlowdermilk): remove this after eliminating downstream dependencies.
-	Kind string `yaml:"kind,omitempty"`
+	Kind string `json:"kind,omitempty"`
 	// DEPRECATED: APIVersion is the preferred api version for communicating with the kubernetes cluster (v1, v2, etc).
 	// Because a cluster can run multiple API groups and potentially multiple versions of each, it no longer makes sense to specify
 	// a single value for the cluster version.
 	// This field isn't really needed anyway, so we are deprecating it without replacement.
 	// It will be ignored if it is present.
-	APIVersion string `yaml:"apiVersion,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
 	// Preferences holds general information to be use for cli interactions
-	Preferences Preferences `yaml:"preferences"`
+	Preferences Preferences `json:"preferences"`
 	// Clusters is a map of referencable names to cluster configs
-	Clusters []NamedCluster `yaml:"clusters"`
+	Clusters []NamedCluster `json:"clusters"`
 	// AuthInfos is a map of referencable names to user configs
-	AuthInfos []NamedAuthInfo `yaml:"users"`
+	AuthInfos []NamedAuthInfo `json:"users"`
 	// Contexts is a map of referencable names to context configs
-	Contexts []NamedContext `yaml:"contexts"`
+	Contexts []NamedContext `json:"contexts"`
 	// CurrentContext is the name of the context that you would like to use by default
-	CurrentContext string `yaml:"current-context"`
+	CurrentContext string `json:"current-context"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
-	Extensions []NamedExtension `yaml:"extensions,omitempty"`
+	Extensions []NamedExtension `json:"extensions,omitempty"`
 }
 
 // Preferences contains information about the users command line experience preferences.
 type Preferences struct {
-	Colors bool `yaml:"colors,omitempty"`
+	Colors bool `json:"colors,omitempty"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
-	Extensions []NamedExtension `yaml:"extensions,omitempty"`
+	Extensions []NamedExtension `json:"extensions,omitempty"`
 }
 
 // Cluster contains information about how to communicate with a kubernetes cluster
 type Cluster struct {
 	// Server is the address of the kubernetes cluster (https://hostname:port).
-	Server string `yaml:"server"`
+	Server string `json:"server"`
 	// APIVersion is the preferred api version for communicating with the kubernetes cluster (v1, v2, etc).
-	APIVersion string `yaml:"api-version,omitempty"`
+	APIVersion string `json:"api-version,omitempty"`
 	// InsecureSkipTLSVerify skips the validity check for the server's certificate. This will make your HTTPS connections insecure.
-	InsecureSkipTLSVerify bool `yaml:"insecure-skip-tls-verify,omitempty"`
+	InsecureSkipTLSVerify bool `json:"insecure-skip-tls-verify,omitempty"`
 	// CertificateAuthority is the path to a cert file for the certificate authority.
-	CertificateAuthority string `yaml:"certificate-authority,omitempty"`
+	CertificateAuthority string `json:"certificate-authority,omitempty"`
 	// CertificateAuthorityData contains PEM-encoded certificate authority certificates. Overrides CertificateAuthority
 	//
 	// NOTE(ericchiang): Our yaml parser doesn't assume []byte is a base64 encoded string.
-	CertificateAuthorityData string `yaml:"certificate-authority-data,omitempty"`
+	CertificateAuthorityData string `json:"certificate-authority-data,omitempty"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
-	Extensions []NamedExtension `yaml:"extensions,omitempty"`
+	Extensions []NamedExtension `json:"extensions,omitempty"`
 }
 
 // AuthInfo contains information that describes identity information.  This is use to tell the kubernetes cluster who you are.
 type AuthInfo struct {
 	// ClientCertificate is the path to a client cert file for TLS.
-	ClientCertificate string `yaml:"client-certificate,omitempty"`
+	ClientCertificate string `json:"client-certificate,omitempty"`
 	// ClientCertificateData contains PEM-encoded data from a client cert file for TLS. Overrides ClientCertificate
 	//
 	// NOTE(ericchiang): Our yaml parser doesn't assume []byte is a base64 encoded string.
-	ClientCertificateData string `yaml:"client-certificate-data,omitempty"`
+	ClientCertificateData string `json:"client-certificate-data,omitempty"`
 	// ClientKey is the path to a client key file for TLS.
-	ClientKey string `yaml:"client-key,omitempty"`
+	ClientKey string `json:"client-key,omitempty"`
 	// ClientKeyData contains PEM-encoded data from a client key file for TLS. Overrides ClientKey
 	//
 	// NOTE(ericchiang): Our yaml parser doesn't assume []byte is a base64 encoded string.
-	ClientKeyData string `yaml:"client-key-data,omitempty"`
+	ClientKeyData string `json:"client-key-data,omitempty"`
 	// Token is the bearer token for authentication to the kubernetes cluster.
-	Token string `yaml:"token,omitempty"`
+	Token string `json:"token,omitempty"`
 	// Impersonate is the username to imperonate.  The name matches the flag.
-	Impersonate string `yaml:"as,omitempty"`
+	Impersonate string `json:"as,omitempty"`
 	// Username is the username for basic authentication to the kubernetes cluster.
-	Username string `yaml:"username,omitempty"`
+	Username string `json:"username,omitempty"`
 	// Password is the password for basic authentication to the kubernetes cluster.
-	Password string `yaml:"password,omitempty"`
+	Password string `json:"password,omitempty"`
 	// AuthProvider specifies a custom authentication plugin for the kubernetes cluster.
-	AuthProvider *AuthProviderConfig `yaml:"auth-provider,omitempty"`
+	AuthProvider *AuthProviderConfig `json:"auth-provider,omitempty"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
-	Extensions []NamedExtension `yaml:"extensions,omitempty"`
+	Extensions []NamedExtension `json:"extensions,omitempty"`
 }
 
 // Context is a tuple of references to a cluster (how do I communicate with a kubernetes cluster), a user (how do I identify myself), and a namespace (what subset of resources do I want to work with)
 type Context struct {
 	// Cluster is the name of the cluster for this context
-	Cluster string `yaml:"cluster"`
+	Cluster string `json:"cluster"`
 	// AuthInfo is the name of the authInfo for this context
-	AuthInfo string `yaml:"user"`
+	AuthInfo string `json:"user"`
 	// Namespace is the default namespace to use on unspecified requests
-	Namespace string `yaml:"namespace,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
-	Extensions []NamedExtension `yaml:"extensions,omitempty"`
+	Extensions []NamedExtension `json:"extensions,omitempty"`
 }
 
 // NamedCluster relates nicknames to cluster information
 type NamedCluster struct {
 	// Name is the nickname for this Cluster
-	Name string `yaml:"name"`
+	Name string `json:"name"`
 	// Cluster holds the cluster information
-	Cluster Cluster `yaml:"cluster"`
+	Cluster Cluster `json:"cluster"`
 }
 
 // NamedContext relates nicknames to context information
 type NamedContext struct {
 	// Name is the nickname for this Context
-	Name string `yaml:"name"`
+	Name string `json:"name"`
 	// Context holds the context information
-	Context Context `yaml:"context"`
+	Context Context `json:"context"`
 }
 
 // NamedAuthInfo relates nicknames to auth information
 type NamedAuthInfo struct {
 	// Name is the nickname for this AuthInfo
-	Name string `yaml:"name"`
+	Name string `json:"name"`
 	// AuthInfo holds the auth information
-	AuthInfo AuthInfo `yaml:"user"`
+	AuthInfo AuthInfo `json:"user"`
 }
 
 // NamedExtension relates nicknames to extension information
 type NamedExtension struct {
 	// Name is the nickname for this Extension
-	Name string `yaml:"name"`
+	Name string `json:"name"`
 }
 
 // AuthProviderConfig holds the configuration for a specified auth provider.
 type AuthProviderConfig struct {
-	Name   string            `yaml:"name"`
-	Config map[string]string `yaml:"config"`
+	Name   string            `json:"name"`
+	Config map[string]string `json:"config"`
 }

--- a/storage/kubernetes/storage.go
+++ b/storage/kubernetes/storage.go
@@ -34,8 +34,8 @@ const (
 
 // Config values for the Kubernetes storage type.
 type Config struct {
-	InCluster      bool   `yaml:"inCluster"`
-	KubeConfigFile string `yaml:"kubeConfigFile"`
+	InCluster      bool   `json:"inCluster"`
+	KubeConfigFile string `json:"kubeConfigFile"`
 }
 
 // Open returns a storage using Kubernetes third party resource.

--- a/storage/sql/config.go
+++ b/storage/sql/config.go
@@ -12,7 +12,7 @@ import (
 // SQLite3 options for creating an SQL db.
 type SQLite3 struct {
 	// File to
-	File string `yaml:"file"`
+	File string `json:"file"`
 }
 
 // Open creates a new storage implementation backed by SQLite3

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -247,16 +247,16 @@ type Password struct {
 	//
 	// Storages that don't support an extended character set for IDs, such as '.' and '@'
 	// (cough cough, kubernetes), must map this value appropriately.
-	Email string `yaml:"email"`
+	Email string `json:"email"`
 
 	// Bcrypt encoded hash of the password. This package enforces a min cost value of 10
-	Hash []byte `yaml:"hash"`
+	Hash []byte `json:"hash"`
 
 	// Optional username to display. NOT used during login.
-	Username string `yaml:"username"`
+	Username string `json:"username"`
 
 	// Randomly generated user ID. This is NOT the primary ID of the Password object.
-	UserID string `yaml:"userID"`
+	UserID string `json:"userID"`
 }
 
 // VerificationKey is a rotated signing key which can still be used to verify

--- a/vendor/github.com/ghodss/yaml/.gitignore
+++ b/vendor/github.com/ghodss/yaml/.gitignore
@@ -1,0 +1,20 @@
+# OSX leaves these everywhere on SMB shares
+._*
+
+# Eclipse files
+.classpath
+.project
+.settings/**
+
+# Emacs save files
+*~
+
+# Vim-related files
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+
+# Go test binaries
+*.test

--- a/vendor/github.com/ghodss/yaml/.travis.yml
+++ b/vendor/github.com/ghodss/yaml/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+go:
+  - 1.3
+  - 1.4
+script:
+  - go test
+  - go build

--- a/vendor/github.com/ghodss/yaml/LICENSE
+++ b/vendor/github.com/ghodss/yaml/LICENSE
@@ -1,0 +1,50 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Sam Ghods
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/ghodss/yaml/README.md
+++ b/vendor/github.com/ghodss/yaml/README.md
@@ -1,0 +1,120 @@
+# YAML marshaling and unmarshaling support for Go
+
+[![Build Status](https://travis-ci.org/ghodss/yaml.svg)](https://travis-ci.org/ghodss/yaml)
+
+## Introduction
+
+A wrapper around [go-yaml](https://github.com/go-yaml/yaml) designed to enable a better way of handling YAML when marshaling to and from structs.
+
+In short, this library first converts YAML to JSON using go-yaml and then uses `json.Marshal` and `json.Unmarshal` to convert to or from the struct. This means that it effectively reuses the JSON struct tags as well as the custom JSON methods `MarshalJSON` and `UnmarshalJSON` unlike go-yaml. For a detailed overview of the rationale behind this method, [see this blog post](http://ghodss.com/2014/the-right-way-to-handle-yaml-in-golang/).
+
+## Compatibility
+
+This package uses [go-yaml](https://github.com/go-yaml/yaml) and therefore supports [everything go-yaml supports](https://github.com/go-yaml/yaml#compatibility).
+
+## Caveats
+
+**Caveat #1:** When using `yaml.Marshal` and `yaml.Unmarshal`, binary data should NOT be preceded with the `!!binary` YAML tag. If you do, candiedyaml will convert the binary data from base64 to native binary data, which is not compatible with JSON. You can still use binary in your YAML files though - just store them without the `!!binary` tag and decode the base64 in your code (e.g. in the custom JSON methods `MarshalJSON` and `UnmarshalJSON`). This also has the benefit that your YAML and your JSON binary data will be decoded exactly the same way. As an example:
+
+```
+BAD:
+	exampleKey: !!binary gIGC
+
+GOOD:
+	exampleKey: gIGC
+... and decode the base64 data in your code.
+```
+
+**Caveat #2:** When using `YAMLToJSON` directly, maps with keys that are maps will result in an error since this is not supported by JSON. This error will occur in `Unmarshal` as well since you can't unmarshal map keys anyways since struct fields can't be keys.
+
+## Installation and usage
+
+To install, run:
+
+```
+$ go get github.com/ghodss/yaml
+```
+
+And import using:
+
+```
+import "github.com/ghodss/yaml"
+```
+
+Usage is very similar to the JSON library:
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
+)
+
+type Person struct {
+	Name string `json:"name"`  // Affects YAML field names too.
+	Age int `json:"age"`
+}
+
+func main() {
+	// Marshal a Person struct to YAML.
+	p := Person{"John", 30}
+	y, err := yaml.Marshal(p)
+	if err != nil {
+		fmt.Printf("err: %v\n", err)
+		return
+	}
+	fmt.Println(string(y))
+	/* Output:
+	age: 30
+	name: John
+	*/
+
+	// Unmarshal the YAML back into a Person struct.
+	var p2 Person
+	err = yaml.Unmarshal(y, &p2)
+	if err != nil {
+		fmt.Printf("err: %v\n", err)
+		return
+	}
+	fmt.Println(p2)
+	/* Output:
+	{John 30}
+	*/
+}
+```
+
+`yaml.YAMLToJSON` and `yaml.JSONToYAML` methods are also available:
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
+)
+func main() {
+	j := []byte(`{"name": "John", "age": 30}`)
+	y, err := yaml.JSONToYAML(j)
+	if err != nil {
+		fmt.Printf("err: %v\n", err)
+		return
+	}
+	fmt.Println(string(y))
+	/* Output:
+	name: John
+	age: 30
+	*/
+	j2, err := yaml.YAMLToJSON(y)
+	if err != nil {
+		fmt.Printf("err: %v\n", err)
+		return
+	}
+	fmt.Println(string(j2))
+	/* Output:
+	{"age":30,"name":"John"}
+	*/
+}
+```

--- a/vendor/github.com/ghodss/yaml/fields.go
+++ b/vendor/github.com/ghodss/yaml/fields.go
@@ -1,0 +1,497 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package yaml
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"unicode"
+	"unicode/utf8"
+)
+
+// indirect walks down v allocating pointers as needed,
+// until it gets to a non-pointer.
+// if it encounters an Unmarshaler, indirect stops and returns that.
+// if decodingNull is true, indirect stops at the last pointer so it can be set to nil.
+func indirect(v reflect.Value, decodingNull bool) (json.Unmarshaler, encoding.TextUnmarshaler, reflect.Value) {
+	// If v is a named type and is addressable,
+	// start with its address, so that if the type has pointer methods,
+	// we find them.
+	if v.Kind() != reflect.Ptr && v.Type().Name() != "" && v.CanAddr() {
+		v = v.Addr()
+	}
+	for {
+		// Load value from interface, but only if the result will be
+		// usefully addressable.
+		if v.Kind() == reflect.Interface && !v.IsNil() {
+			e := v.Elem()
+			if e.Kind() == reflect.Ptr && !e.IsNil() && (!decodingNull || e.Elem().Kind() == reflect.Ptr) {
+				v = e
+				continue
+			}
+		}
+
+		if v.Kind() != reflect.Ptr {
+			break
+		}
+
+		if v.Elem().Kind() != reflect.Ptr && decodingNull && v.CanSet() {
+			break
+		}
+		if v.IsNil() {
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+		if v.Type().NumMethod() > 0 {
+			if u, ok := v.Interface().(json.Unmarshaler); ok {
+				return u, nil, reflect.Value{}
+			}
+			if u, ok := v.Interface().(encoding.TextUnmarshaler); ok {
+				return nil, u, reflect.Value{}
+			}
+		}
+		v = v.Elem()
+	}
+	return nil, nil, v
+}
+
+// A field represents a single field found in a struct.
+type field struct {
+	name      string
+	nameBytes []byte                 // []byte(name)
+	equalFold func(s, t []byte) bool // bytes.EqualFold or equivalent
+
+	tag       bool
+	index     []int
+	typ       reflect.Type
+	omitEmpty bool
+	quoted    bool
+}
+
+func fillField(f field) field {
+	f.nameBytes = []byte(f.name)
+	f.equalFold = foldFunc(f.nameBytes)
+	return f
+}
+
+// byName sorts field by name, breaking ties with depth,
+// then breaking ties with "name came from json tag", then
+// breaking ties with index sequence.
+type byName []field
+
+func (x byName) Len() int { return len(x) }
+
+func (x byName) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+func (x byName) Less(i, j int) bool {
+	if x[i].name != x[j].name {
+		return x[i].name < x[j].name
+	}
+	if len(x[i].index) != len(x[j].index) {
+		return len(x[i].index) < len(x[j].index)
+	}
+	if x[i].tag != x[j].tag {
+		return x[i].tag
+	}
+	return byIndex(x).Less(i, j)
+}
+
+// byIndex sorts field by index sequence.
+type byIndex []field
+
+func (x byIndex) Len() int { return len(x) }
+
+func (x byIndex) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+func (x byIndex) Less(i, j int) bool {
+	for k, xik := range x[i].index {
+		if k >= len(x[j].index) {
+			return false
+		}
+		if xik != x[j].index[k] {
+			return xik < x[j].index[k]
+		}
+	}
+	return len(x[i].index) < len(x[j].index)
+}
+
+// typeFields returns a list of fields that JSON should recognize for the given type.
+// The algorithm is breadth-first search over the set of structs to include - the top struct
+// and then any reachable anonymous structs.
+func typeFields(t reflect.Type) []field {
+	// Anonymous fields to explore at the current level and the next.
+	current := []field{}
+	next := []field{{typ: t}}
+
+	// Count of queued names for current level and the next.
+	count := map[reflect.Type]int{}
+	nextCount := map[reflect.Type]int{}
+
+	// Types already visited at an earlier level.
+	visited := map[reflect.Type]bool{}
+
+	// Fields found.
+	var fields []field
+
+	for len(next) > 0 {
+		current, next = next, current[:0]
+		count, nextCount = nextCount, map[reflect.Type]int{}
+
+		for _, f := range current {
+			if visited[f.typ] {
+				continue
+			}
+			visited[f.typ] = true
+
+			// Scan f.typ for fields to include.
+			for i := 0; i < f.typ.NumField(); i++ {
+				sf := f.typ.Field(i)
+				if sf.PkgPath != "" { // unexported
+					continue
+				}
+				tag := sf.Tag.Get("json")
+				if tag == "-" {
+					continue
+				}
+				name, opts := parseTag(tag)
+				if !isValidTag(name) {
+					name = ""
+				}
+				index := make([]int, len(f.index)+1)
+				copy(index, f.index)
+				index[len(f.index)] = i
+
+				ft := sf.Type
+				if ft.Name() == "" && ft.Kind() == reflect.Ptr {
+					// Follow pointer.
+					ft = ft.Elem()
+				}
+
+				// Record found field and index sequence.
+				if name != "" || !sf.Anonymous || ft.Kind() != reflect.Struct {
+					tagged := name != ""
+					if name == "" {
+						name = sf.Name
+					}
+					fields = append(fields, fillField(field{
+						name:      name,
+						tag:       tagged,
+						index:     index,
+						typ:       ft,
+						omitEmpty: opts.Contains("omitempty"),
+						quoted:    opts.Contains("string"),
+					}))
+					if count[f.typ] > 1 {
+						// If there were multiple instances, add a second,
+						// so that the annihilation code will see a duplicate.
+						// It only cares about the distinction between 1 or 2,
+						// so don't bother generating any more copies.
+						fields = append(fields, fields[len(fields)-1])
+					}
+					continue
+				}
+
+				// Record new anonymous struct to explore in next round.
+				nextCount[ft]++
+				if nextCount[ft] == 1 {
+					next = append(next, fillField(field{name: ft.Name(), index: index, typ: ft}))
+				}
+			}
+		}
+	}
+
+	sort.Sort(byName(fields))
+
+	// Delete all fields that are hidden by the Go rules for embedded fields,
+	// except that fields with JSON tags are promoted.
+
+	// The fields are sorted in primary order of name, secondary order
+	// of field index length. Loop over names; for each name, delete
+	// hidden fields by choosing the one dominant field that survives.
+	out := fields[:0]
+	for advance, i := 0, 0; i < len(fields); i += advance {
+		// One iteration per name.
+		// Find the sequence of fields with the name of this first field.
+		fi := fields[i]
+		name := fi.name
+		for advance = 1; i+advance < len(fields); advance++ {
+			fj := fields[i+advance]
+			if fj.name != name {
+				break
+			}
+		}
+		if advance == 1 { // Only one field with this name
+			out = append(out, fi)
+			continue
+		}
+		dominant, ok := dominantField(fields[i : i+advance])
+		if ok {
+			out = append(out, dominant)
+		}
+	}
+
+	fields = out
+	sort.Sort(byIndex(fields))
+
+	return fields
+}
+
+// dominantField looks through the fields, all of which are known to
+// have the same name, to find the single field that dominates the
+// others using Go's embedding rules, modified by the presence of
+// JSON tags. If there are multiple top-level fields, the boolean
+// will be false: This condition is an error in Go and we skip all
+// the fields.
+func dominantField(fields []field) (field, bool) {
+	// The fields are sorted in increasing index-length order. The winner
+	// must therefore be one with the shortest index length. Drop all
+	// longer entries, which is easy: just truncate the slice.
+	length := len(fields[0].index)
+	tagged := -1 // Index of first tagged field.
+	for i, f := range fields {
+		if len(f.index) > length {
+			fields = fields[:i]
+			break
+		}
+		if f.tag {
+			if tagged >= 0 {
+				// Multiple tagged fields at the same level: conflict.
+				// Return no field.
+				return field{}, false
+			}
+			tagged = i
+		}
+	}
+	if tagged >= 0 {
+		return fields[tagged], true
+	}
+	// All remaining fields have the same length. If there's more than one,
+	// we have a conflict (two fields named "X" at the same level) and we
+	// return no field.
+	if len(fields) > 1 {
+		return field{}, false
+	}
+	return fields[0], true
+}
+
+var fieldCache struct {
+	sync.RWMutex
+	m map[reflect.Type][]field
+}
+
+// cachedTypeFields is like typeFields but uses a cache to avoid repeated work.
+func cachedTypeFields(t reflect.Type) []field {
+	fieldCache.RLock()
+	f := fieldCache.m[t]
+	fieldCache.RUnlock()
+	if f != nil {
+		return f
+	}
+
+	// Compute fields without lock.
+	// Might duplicate effort but won't hold other computations back.
+	f = typeFields(t)
+	if f == nil {
+		f = []field{}
+	}
+
+	fieldCache.Lock()
+	if fieldCache.m == nil {
+		fieldCache.m = map[reflect.Type][]field{}
+	}
+	fieldCache.m[t] = f
+	fieldCache.Unlock()
+	return f
+}
+
+func isValidTag(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case strings.ContainsRune("!#$%&()*+-./:<=>?@[]^_{|}~ ", c):
+			// Backslash and quote chars are reserved, but
+			// otherwise any punctuation chars are allowed
+			// in a tag name.
+		default:
+			if !unicode.IsLetter(c) && !unicode.IsDigit(c) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+const (
+	caseMask     = ^byte(0x20) // Mask to ignore case in ASCII.
+	kelvin       = '\u212a'
+	smallLongEss = '\u017f'
+)
+
+// foldFunc returns one of four different case folding equivalence
+// functions, from most general (and slow) to fastest:
+//
+// 1) bytes.EqualFold, if the key s contains any non-ASCII UTF-8
+// 2) equalFoldRight, if s contains special folding ASCII ('k', 'K', 's', 'S')
+// 3) asciiEqualFold, no special, but includes non-letters (including _)
+// 4) simpleLetterEqualFold, no specials, no non-letters.
+//
+// The letters S and K are special because they map to 3 runes, not just 2:
+//  * S maps to s and to U+017F 'ſ' Latin small letter long s
+//  * k maps to K and to U+212A 'K' Kelvin sign
+// See http://play.golang.org/p/tTxjOc0OGo
+//
+// The returned function is specialized for matching against s and
+// should only be given s. It's not curried for performance reasons.
+func foldFunc(s []byte) func(s, t []byte) bool {
+	nonLetter := false
+	special := false // special letter
+	for _, b := range s {
+		if b >= utf8.RuneSelf {
+			return bytes.EqualFold
+		}
+		upper := b & caseMask
+		if upper < 'A' || upper > 'Z' {
+			nonLetter = true
+		} else if upper == 'K' || upper == 'S' {
+			// See above for why these letters are special.
+			special = true
+		}
+	}
+	if special {
+		return equalFoldRight
+	}
+	if nonLetter {
+		return asciiEqualFold
+	}
+	return simpleLetterEqualFold
+}
+
+// equalFoldRight is a specialization of bytes.EqualFold when s is
+// known to be all ASCII (including punctuation), but contains an 's',
+// 'S', 'k', or 'K', requiring a Unicode fold on the bytes in t.
+// See comments on foldFunc.
+func equalFoldRight(s, t []byte) bool {
+	for _, sb := range s {
+		if len(t) == 0 {
+			return false
+		}
+		tb := t[0]
+		if tb < utf8.RuneSelf {
+			if sb != tb {
+				sbUpper := sb & caseMask
+				if 'A' <= sbUpper && sbUpper <= 'Z' {
+					if sbUpper != tb&caseMask {
+						return false
+					}
+				} else {
+					return false
+				}
+			}
+			t = t[1:]
+			continue
+		}
+		// sb is ASCII and t is not. t must be either kelvin
+		// sign or long s; sb must be s, S, k, or K.
+		tr, size := utf8.DecodeRune(t)
+		switch sb {
+		case 's', 'S':
+			if tr != smallLongEss {
+				return false
+			}
+		case 'k', 'K':
+			if tr != kelvin {
+				return false
+			}
+		default:
+			return false
+		}
+		t = t[size:]
+
+	}
+	if len(t) > 0 {
+		return false
+	}
+	return true
+}
+
+// asciiEqualFold is a specialization of bytes.EqualFold for use when
+// s is all ASCII (but may contain non-letters) and contains no
+// special-folding letters.
+// See comments on foldFunc.
+func asciiEqualFold(s, t []byte) bool {
+	if len(s) != len(t) {
+		return false
+	}
+	for i, sb := range s {
+		tb := t[i]
+		if sb == tb {
+			continue
+		}
+		if ('a' <= sb && sb <= 'z') || ('A' <= sb && sb <= 'Z') {
+			if sb&caseMask != tb&caseMask {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+// simpleLetterEqualFold is a specialization of bytes.EqualFold for
+// use when s is all ASCII letters (no underscores, etc) and also
+// doesn't contain 'k', 'K', 's', or 'S'.
+// See comments on foldFunc.
+func simpleLetterEqualFold(s, t []byte) bool {
+	if len(s) != len(t) {
+		return false
+	}
+	for i, b := range s {
+		if b&caseMask != t[i]&caseMask {
+			return false
+		}
+	}
+	return true
+}
+
+// tagOptions is the string following a comma in a struct field's "json"
+// tag, or the empty string. It does not include the leading comma.
+type tagOptions string
+
+// parseTag splits a struct field's json tag into its name and
+// comma-separated options.
+func parseTag(tag string) (string, tagOptions) {
+	if idx := strings.Index(tag, ","); idx != -1 {
+		return tag[:idx], tagOptions(tag[idx+1:])
+	}
+	return tag, tagOptions("")
+}
+
+// Contains reports whether a comma-separated list of options
+// contains a particular substr flag. substr must be surrounded by a
+// string boundary or commas.
+func (o tagOptions) Contains(optionName string) bool {
+	if len(o) == 0 {
+		return false
+	}
+	s := string(o)
+	for s != "" {
+		var next string
+		i := strings.Index(s, ",")
+		if i >= 0 {
+			s, next = s[:i], s[i+1:]
+		}
+		if s == optionName {
+			return true
+		}
+		s = next
+	}
+	return false
+}

--- a/vendor/github.com/ghodss/yaml/yaml.go
+++ b/vendor/github.com/ghodss/yaml/yaml.go
@@ -1,0 +1,277 @@
+package yaml
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Marshals the object into JSON then converts JSON to YAML and returns the
+// YAML.
+func Marshal(o interface{}) ([]byte, error) {
+	j, err := json.Marshal(o)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling into JSON: %v", err)
+	}
+
+	y, err := JSONToYAML(j)
+	if err != nil {
+		return nil, fmt.Errorf("error converting JSON to YAML: %v", err)
+	}
+
+	return y, nil
+}
+
+// Converts YAML to JSON then uses JSON to unmarshal into an object.
+func Unmarshal(y []byte, o interface{}) error {
+	vo := reflect.ValueOf(o)
+	j, err := yamlToJSON(y, &vo)
+	if err != nil {
+		return fmt.Errorf("error converting YAML to JSON: %v", err)
+	}
+
+	err = json.Unmarshal(j, o)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling JSON: %v", err)
+	}
+
+	return nil
+}
+
+// Convert JSON to YAML.
+func JSONToYAML(j []byte) ([]byte, error) {
+	// Convert the JSON to an object.
+	var jsonObj interface{}
+	// We are using yaml.Unmarshal here (instead of json.Unmarshal) because the
+	// Go JSON library doesn't try to pick the right number type (int, float,
+	// etc.) when unmarshalling to interface{}, it just picks float64
+	// universally. go-yaml does go through the effort of picking the right
+	// number type, so we can preserve number type throughout this process.
+	err := yaml.Unmarshal(j, &jsonObj)
+	if err != nil {
+		return nil, err
+	}
+
+	// Marshal this object into YAML.
+	return yaml.Marshal(jsonObj)
+}
+
+// Convert YAML to JSON. Since JSON is a subset of YAML, passing JSON through
+// this method should be a no-op.
+//
+// Things YAML can do that are not supported by JSON:
+// * In YAML you can have binary and null keys in your maps. These are invalid
+//   in JSON. (int and float keys are converted to strings.)
+// * Binary data in YAML with the !!binary tag is not supported. If you want to
+//   use binary data with this library, encode the data as base64 as usual but do
+//   not use the !!binary tag in your YAML. This will ensure the original base64
+//   encoded data makes it all the way through to the JSON.
+func YAMLToJSON(y []byte) ([]byte, error) {
+	return yamlToJSON(y, nil)
+}
+
+func yamlToJSON(y []byte, jsonTarget *reflect.Value) ([]byte, error) {
+	// Convert the YAML to an object.
+	var yamlObj interface{}
+	err := yaml.Unmarshal(y, &yamlObj)
+	if err != nil {
+		return nil, err
+	}
+
+	// YAML objects are not completely compatible with JSON objects (e.g. you
+	// can have non-string keys in YAML). So, convert the YAML-compatible object
+	// to a JSON-compatible object, failing with an error if irrecoverable
+	// incompatibilties happen along the way.
+	jsonObj, err := convertToJSONableObject(yamlObj, jsonTarget)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert this object to JSON and return the data.
+	return json.Marshal(jsonObj)
+}
+
+func convertToJSONableObject(yamlObj interface{}, jsonTarget *reflect.Value) (interface{}, error) {
+	var err error
+
+	// Resolve jsonTarget to a concrete value (i.e. not a pointer or an
+	// interface). We pass decodingNull as false because we're not actually
+	// decoding into the value, we're just checking if the ultimate target is a
+	// string.
+	if jsonTarget != nil {
+		ju, tu, pv := indirect(*jsonTarget, false)
+		// We have a JSON or Text Umarshaler at this level, so we can't be trying
+		// to decode into a string.
+		if ju != nil || tu != nil {
+			jsonTarget = nil
+		} else {
+			jsonTarget = &pv
+		}
+	}
+
+	// If yamlObj is a number or a boolean, check if jsonTarget is a string -
+	// if so, coerce.  Else return normal.
+	// If yamlObj is a map or array, find the field that each key is
+	// unmarshaling to, and when you recurse pass the reflect.Value for that
+	// field back into this function.
+	switch typedYAMLObj := yamlObj.(type) {
+	case map[interface{}]interface{}:
+		// JSON does not support arbitrary keys in a map, so we must convert
+		// these keys to strings.
+		//
+		// From my reading of go-yaml v2 (specifically the resolve function),
+		// keys can only have the types string, int, int64, float64, binary
+		// (unsupported), or null (unsupported).
+		strMap := make(map[string]interface{})
+		for k, v := range typedYAMLObj {
+			// Resolve the key to a string first.
+			var keyString string
+			switch typedKey := k.(type) {
+			case string:
+				keyString = typedKey
+			case int:
+				keyString = strconv.Itoa(typedKey)
+			case int64:
+				// go-yaml will only return an int64 as a key if the system
+				// architecture is 32-bit and the key's value is between 32-bit
+				// and 64-bit. Otherwise the key type will simply be int.
+				keyString = strconv.FormatInt(typedKey, 10)
+			case float64:
+				// Stolen from go-yaml to use the same conversion to string as
+				// the go-yaml library uses to convert float to string when
+				// Marshaling.
+				s := strconv.FormatFloat(typedKey, 'g', -1, 32)
+				switch s {
+				case "+Inf":
+					s = ".inf"
+				case "-Inf":
+					s = "-.inf"
+				case "NaN":
+					s = ".nan"
+				}
+				keyString = s
+			case bool:
+				if typedKey {
+					keyString = "true"
+				} else {
+					keyString = "false"
+				}
+			default:
+				return nil, fmt.Errorf("Unsupported map key of type: %s, key: %+#v, value: %+#v",
+					reflect.TypeOf(k), k, v)
+			}
+
+			// jsonTarget should be a struct or a map. If it's a struct, find
+			// the field it's going to map to and pass its reflect.Value. If
+			// it's a map, find the element type of the map and pass the
+			// reflect.Value created from that type. If it's neither, just pass
+			// nil - JSON conversion will error for us if it's a real issue.
+			if jsonTarget != nil {
+				t := *jsonTarget
+				if t.Kind() == reflect.Struct {
+					keyBytes := []byte(keyString)
+					// Find the field that the JSON library would use.
+					var f *field
+					fields := cachedTypeFields(t.Type())
+					for i := range fields {
+						ff := &fields[i]
+						if bytes.Equal(ff.nameBytes, keyBytes) {
+							f = ff
+							break
+						}
+						// Do case-insensitive comparison.
+						if f == nil && ff.equalFold(ff.nameBytes, keyBytes) {
+							f = ff
+						}
+					}
+					if f != nil {
+						// Find the reflect.Value of the most preferential
+						// struct field.
+						jtf := t.Field(f.index[0])
+						strMap[keyString], err = convertToJSONableObject(v, &jtf)
+						if err != nil {
+							return nil, err
+						}
+						continue
+					}
+				} else if t.Kind() == reflect.Map {
+					// Create a zero value of the map's element type to use as
+					// the JSON target.
+					jtv := reflect.Zero(t.Type().Elem())
+					strMap[keyString], err = convertToJSONableObject(v, &jtv)
+					if err != nil {
+						return nil, err
+					}
+					continue
+				}
+			}
+			strMap[keyString], err = convertToJSONableObject(v, nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return strMap, nil
+	case []interface{}:
+		// We need to recurse into arrays in case there are any
+		// map[interface{}]interface{}'s inside and to convert any
+		// numbers to strings.
+
+		// If jsonTarget is a slice (which it really should be), find the
+		// thing it's going to map to. If it's not a slice, just pass nil
+		// - JSON conversion will error for us if it's a real issue.
+		var jsonSliceElemValue *reflect.Value
+		if jsonTarget != nil {
+			t := *jsonTarget
+			if t.Kind() == reflect.Slice {
+				// By default slices point to nil, but we need a reflect.Value
+				// pointing to a value of the slice type, so we create one here.
+				ev := reflect.Indirect(reflect.New(t.Type().Elem()))
+				jsonSliceElemValue = &ev
+			}
+		}
+
+		// Make and use a new array.
+		arr := make([]interface{}, len(typedYAMLObj))
+		for i, v := range typedYAMLObj {
+			arr[i], err = convertToJSONableObject(v, jsonSliceElemValue)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return arr, nil
+	default:
+		// If the target type is a string and the YAML type is a number,
+		// convert the YAML type to a string.
+		if jsonTarget != nil && (*jsonTarget).Kind() == reflect.String {
+			// Based on my reading of go-yaml, it may return int, int64,
+			// float64, or uint64.
+			var s string
+			switch typedVal := typedYAMLObj.(type) {
+			case int:
+				s = strconv.FormatInt(int64(typedVal), 10)
+			case int64:
+				s = strconv.FormatInt(typedVal, 10)
+			case float64:
+				s = strconv.FormatFloat(typedVal, 'g', -1, 32)
+			case uint64:
+				s = strconv.FormatUint(typedVal, 10)
+			case bool:
+				if typedVal {
+					s = "true"
+				} else {
+					s = "false"
+				}
+			}
+			if len(s) > 0 {
+				yamlObj = interface{}(s)
+			}
+		}
+		return yamlObj, nil
+	}
+
+	return nil, nil
+}

--- a/vendor/github.com/ghodss/yaml/yaml_test.go
+++ b/vendor/github.com/ghodss/yaml/yaml_test.go
@@ -1,0 +1,271 @@
+package yaml
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+type MarshalTest struct {
+	A string
+	B int64
+	// Would like to test float64, but it's not supported in go-yaml.
+	// (See https://github.com/go-yaml/yaml/issues/83.)
+	C float32
+}
+
+func TestMarshal(t *testing.T) {
+	f32String := strconv.FormatFloat(math.MaxFloat32, 'g', -1, 32)
+	s := MarshalTest{"a", math.MaxInt64, math.MaxFloat32}
+	e := []byte(fmt.Sprintf("A: a\nB: %d\nC: %s\n", math.MaxInt64, f32String))
+
+	y, err := Marshal(s)
+	if err != nil {
+		t.Errorf("error marshaling YAML: %v", err)
+	}
+
+	if !reflect.DeepEqual(y, e) {
+		t.Errorf("marshal YAML was unsuccessful, expected: %#v, got: %#v",
+			string(e), string(y))
+	}
+}
+
+type UnmarshalString struct {
+	A    string
+	True string
+}
+
+type UnmarshalStringMap struct {
+	A map[string]string
+}
+
+type UnmarshalNestedString struct {
+	A NestedString
+}
+
+type NestedString struct {
+	A string
+}
+
+type UnmarshalSlice struct {
+	A []NestedSlice
+}
+
+type NestedSlice struct {
+	B string
+	C *string
+}
+
+func TestUnmarshal(t *testing.T) {
+	y := []byte("a: 1")
+	s1 := UnmarshalString{}
+	e1 := UnmarshalString{A: "1"}
+	unmarshal(t, y, &s1, &e1)
+
+	y = []byte("a: true")
+	s1 = UnmarshalString{}
+	e1 = UnmarshalString{A: "true"}
+	unmarshal(t, y, &s1, &e1)
+
+	y = []byte("true: 1")
+	s1 = UnmarshalString{}
+	e1 = UnmarshalString{True: "1"}
+	unmarshal(t, y, &s1, &e1)
+
+	y = []byte("a:\n  a: 1")
+	s2 := UnmarshalNestedString{}
+	e2 := UnmarshalNestedString{NestedString{"1"}}
+	unmarshal(t, y, &s2, &e2)
+
+	y = []byte("a:\n  - b: abc\n    c: def\n  - b: 123\n    c: 456\n")
+	s3 := UnmarshalSlice{}
+	e3 := UnmarshalSlice{[]NestedSlice{NestedSlice{"abc", strPtr("def")}, NestedSlice{"123", strPtr("456")}}}
+	unmarshal(t, y, &s3, &e3)
+
+	y = []byte("a:\n  b: 1")
+	s4 := UnmarshalStringMap{}
+	e4 := UnmarshalStringMap{map[string]string{"b": "1"}}
+	unmarshal(t, y, &s4, &e4)
+}
+
+func unmarshal(t *testing.T, y []byte, s, e interface{}) {
+	err := Unmarshal(y, s)
+	if err != nil {
+		t.Errorf("error unmarshaling YAML: %v", err)
+	}
+
+	if !reflect.DeepEqual(s, e) {
+		t.Errorf("unmarshal YAML was unsuccessful, expected: %+#v, got: %+#v",
+			e, s)
+	}
+}
+
+type Case struct {
+	input  string
+	output string
+	// By default we test that reversing the output == input. But if there is a
+	// difference in the reversed output, you can optionally specify it here.
+	reverse *string
+}
+
+type RunType int
+
+const (
+	RunTypeJSONToYAML RunType = iota
+	RunTypeYAMLToJSON
+)
+
+func TestJSONToYAML(t *testing.T) {
+	cases := []Case{
+		{
+			`{"t":"a"}`,
+			"t: a\n",
+			nil,
+		}, {
+			`{"t":null}`,
+			"t: null\n",
+			nil,
+		},
+	}
+
+	runCases(t, RunTypeJSONToYAML, cases)
+}
+
+func TestYAMLToJSON(t *testing.T) {
+	cases := []Case{
+		{
+			"t: a\n",
+			`{"t":"a"}`,
+			nil,
+		}, {
+			"t: \n",
+			`{"t":null}`,
+			strPtr("t: null\n"),
+		}, {
+			"t: null\n",
+			`{"t":null}`,
+			nil,
+		}, {
+			"1: a\n",
+			`{"1":"a"}`,
+			strPtr("\"1\": a\n"),
+		}, {
+			"1000000000000000000000000000000000000: a\n",
+			`{"1e+36":"a"}`,
+			strPtr("\"1e+36\": a\n"),
+		}, {
+			"1e+36: a\n",
+			`{"1e+36":"a"}`,
+			strPtr("\"1e+36\": a\n"),
+		}, {
+			"\"1e+36\": a\n",
+			`{"1e+36":"a"}`,
+			nil,
+		}, {
+			"\"1.2\": a\n",
+			`{"1.2":"a"}`,
+			nil,
+		}, {
+			"- t: a\n",
+			`[{"t":"a"}]`,
+			nil,
+		}, {
+			"- t: a\n" +
+				"- t:\n" +
+				"    b: 1\n" +
+				"    c: 2\n",
+			`[{"t":"a"},{"t":{"b":1,"c":2}}]`,
+			nil,
+		}, {
+			`[{t: a}, {t: {b: 1, c: 2}}]`,
+			`[{"t":"a"},{"t":{"b":1,"c":2}}]`,
+			strPtr("- t: a\n" +
+				"- t:\n" +
+				"    b: 1\n" +
+				"    c: 2\n"),
+		}, {
+			"- t: \n",
+			`[{"t":null}]`,
+			strPtr("- t: null\n"),
+		}, {
+			"- t: null\n",
+			`[{"t":null}]`,
+			nil,
+		},
+	}
+
+	// Cases that should produce errors.
+	_ = []Case{
+		{
+			"~: a",
+			`{"null":"a"}`,
+			nil,
+		}, {
+			"a: !!binary gIGC\n",
+			"{\"a\":\"\x80\x81\x82\"}",
+			nil,
+		},
+	}
+
+	runCases(t, RunTypeYAMLToJSON, cases)
+}
+
+func runCases(t *testing.T, runType RunType, cases []Case) {
+	var f func([]byte) ([]byte, error)
+	var invF func([]byte) ([]byte, error)
+	var msg string
+	var invMsg string
+	if runType == RunTypeJSONToYAML {
+		f = JSONToYAML
+		invF = YAMLToJSON
+		msg = "JSON to YAML"
+		invMsg = "YAML back to JSON"
+	} else {
+		f = YAMLToJSON
+		invF = JSONToYAML
+		msg = "YAML to JSON"
+		invMsg = "JSON back to YAML"
+	}
+
+	for _, c := range cases {
+		// Convert the string.
+		t.Logf("converting %s\n", c.input)
+		output, err := f([]byte(c.input))
+		if err != nil {
+			t.Errorf("Failed to convert %s, input: `%s`, err: %v", msg, c.input, err)
+		}
+
+		// Check it against the expected output.
+		if string(output) != c.output {
+			t.Errorf("Failed to convert %s, input: `%s`, expected `%s`, got `%s`",
+				msg, c.input, c.output, string(output))
+		}
+
+		// Set the string that we will compare the reversed output to.
+		reverse := c.input
+		// If a special reverse string was specified, use that instead.
+		if c.reverse != nil {
+			reverse = *c.reverse
+		}
+
+		// Reverse the output.
+		input, err := invF(output)
+		if err != nil {
+			t.Errorf("Failed to convert %s, input: `%s`, err: %v", invMsg, string(output), err)
+		}
+
+		// Check the reverse is equal to the input (or to *c.reverse).
+		if string(input) != reverse {
+			t.Errorf("Failed to convert %s, input: `%s`, expected `%s`, got `%s`",
+				invMsg, string(output), reverse, string(input))
+		}
+	}
+
+}
+
+// To be able to easily fill in the *Case.reverse string above.
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
ghodss/yaml converts from YAML to JSON before attempting to unmarshal.
This allows us to:

* Get the correct behavor when decoding base64'd []byte slices.
* Use *json.RawMessage.
* Not have to support extravagant YAML features.
* Let our structs use `json:` tags

cc @rithujohn191 