### PR TITLE
cmd/dex: only expand from env for storages and connectors

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -145,7 +146,8 @@ func (s *Storage) UnmarshalJSON(b []byte) error {
 
 	storageConfig := f()
 	if len(store.Config) != 0 {
-		if err := json.Unmarshal([]byte(store.Config), storageConfig); err != nil {
+		data := []byte(os.ExpandEnv(string(store.Config)))
+		if err := json.Unmarshal(data, storageConfig); err != nil {
 			return fmt.Errorf("parse storace config: %v", err)
 		}
 	}
@@ -199,7 +201,8 @@ func (c *Connector) UnmarshalJSON(b []byte) error {
 
 	connConfig := f()
 	if len(conn.Config) != 0 {
-		if err := json.Unmarshal([]byte(conn.Config), connConfig); err != nil {
+		data := []byte(os.ExpandEnv(string(conn.Config)))
+		if err := json.Unmarshal(data, connConfig); err != nil {
 			return fmt.Errorf("parse connector config: %v", err)
 		}
 	}

--- a/cmd/dex/config_test.go
+++ b/cmd/dex/config_test.go
@@ -39,9 +39,8 @@ connectors:
   name: Google
   config:
     issuer: https://accounts.google.com
-    #  Config values starting with a "$" will read from the environment.
-    clientID: $GOOGLE_CLIENT_ID
-    clientSecret: $GOOGLE_CLIENT_SECRET
+    clientID: foo
+    clientSecret: bar
     redirectURI: http://127.0.0.1:5556/dex/callback/google
 
 enablePasswordDB: true
@@ -96,8 +95,8 @@ expiry:
 				Name: "Google",
 				Config: &oidc.Config{
 					Issuer:       "https://accounts.google.com",
-					ClientID:     "$GOOGLE_CLIENT_ID",
-					ClientSecret: "$GOOGLE_CLIENT_SECRET",
+					ClientID:     "foo",
+					ClientSecret: "bar",
 					RedirectURI:  "http://127.0.0.1:5556/dex/callback/google",
 				},
 			},

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -48,7 +47,6 @@ func serve(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("read config file %s: %v", configFile, err)
 	}
-	configData = []byte(os.ExpandEnv(string(configData)))
 
 	var c Config
 	if err := yaml.Unmarshal(configData, &c); err != nil {

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -58,7 +58,7 @@ enablePasswordDB: true
 staticPasswords:
 - email: "admin@example.com"
   # bcrypt hash of the string "password"
-  hash: "$2a$10$33EMT0cVYVlPy6WAMCLsceLYjWhuHpbz5yuZxu/GAFj03J9Lytjuy"
+  hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
   username: "admin"
   userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
 


### PR DESCRIPTION
Bcrypt'd hashes have "$" characters in them. This means that #667
(accepting actually bcrypted values) combined with #627 (expanding
config with environment variables) broke the example config.

For now, allow storages and connectors to expand their configs from
the environment, but don't do this anywhere else.