### PR TITLE
Dockerfile: add OpenSSL to Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
 FROM alpine:3.4
 
+MAINTAINER Ed Rooth <ed.rooth@coreos.com>
 MAINTAINER Eric Chiang <eric.chiang@coreos.com>
+MAINTAINER Rithu John <rithu.john@coreos.com>
 
-RUN apk add --update ca-certificates 
+# Dex connectors, such as GitHub and Google logins require root certificates.
+# Proper installations should manage those certificates, but it's a bad user
+# experience when this doesn't work out of the box.
+#
+# OpenSSL is required so wget can query HTTPS endpoints for health checking.
+RUN apk add --update ca-certificates openssl
 
 COPY _output/bin/dex /usr/local/bin/dex
 
-ENTRYPOINT ["/usr/local/bin/dex"]
+ENTRYPOINT ["dex"]
 
 CMD ["version"]


### PR DESCRIPTION
Add OpenSSL to the dex Docker container so wget can be used to query
HTTPS endpoints. This is a requirement for health checking when dex is
doing its own TLS termination.

This increased the image size from 20.37 MB to 20.92 MB (+550 KB).

Additionally add Ed and Rithu as maintainers.

Updates #682

cc @rithujohn191 @sym3tri

fyi @dghubble