### PR TITLE
Allow getAttr to return DN

### DIFF
--- a/Documentation/ldap-connector.md
+++ b/Documentation/ldap-connector.md
@@ -11,7 +11,9 @@ The connector executes two primary queries:
 
 ## Configuration
 
-User entries are expected to have an email attribute (configurable through `emailAttr`), and a display name attribute (configurable through `nameAttr`). The following is an example config file that can be used by the LDAP connector to authenticate a user.
+User entries are expected to have an email attribute (configurable through `emailAttr`), and a display name attribute (configurable through `nameAttr`). `*Attr` attributes could be set to "DN" in situations where it is needed but not available elsewhere, and if "DN" attribute does not exist in the record.
+
+The following is an example config file that can be used by the LDAP connector to authenticate a user.
 
 ```yaml
 

--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -47,6 +47,9 @@ import (
 //         baseDN: cn=groups,dc=example,dc=com
 //         filter: "(objectClass=group)"
 //         userAttr: uid
+//         # Use if full DN is needed and not available as any other attribute
+//         # Will only work if "DN" attribute does not exist in the record
+//         # userAttr: DN
 //         groupAttr: member
 //         nameAttr: name
 //
@@ -284,6 +287,9 @@ func getAttr(e ldap.Entry, name string) string {
 			return ""
 		}
 		return a.Values[0]
+	}
+	if name == "DN" {
+		return e.DN
 	}
 	return ""
 }


### PR DESCRIPTION
Specify "DN" as attribute name to return, but will only work if not present in ldap.Entry.Attributes
Use when full DN is stored in groupSearch's userAttr

Related to #536