### PR TITLE
connector: add RefreshConnector interface

### DIFF
--- a/Documentation/github-connector.md
+++ b/Documentation/github-connector.md
@@ -1,0 +1,32 @@
+# Authentication through GitHub
+
+## Overview
+
+One of the login options for dex uses the GitHub OAuth2 flow to identify the end user through their GitHub account.
+
+When a client redeems a refresh token through dex, dex will re-query GitHub to update user information in the ID Token. To do this, __dex stores a readonly GitHub access token in its backing datastore.__ Users that reject dex's access through GitHub will also revoke all dex clients which authenticated them through GitHub.
+
+## Configuration
+
+Register a new application with [GitHub][github-oauth2] ensuring the callback URL is `(dex issuer)/callback`. For example if dex is listening at the non-root path `https://auth.example.com/dex` the callback would be `https://auth.example.com/dex/callback`.
+
+The following is an example of a configuration for `examples/config-dev.yaml`:
+
+```yaml
+connectors:
+- type: github
+  id: github
+  name: GitHub
+  config:
+    # Credentials can be string literals or pulled from the environment.
+    clientID: $GITHUB_CLIENT_ID
+    clientSecret: $GITHUB_CLIENT_SECRET
+    redirectURI: http://127.0.0.1:5556/dex/callback
+    # Optional organization to pull teams from, communicate through the
+    # "groups" scope.
+    #
+    # NOTE: This is an EXPERIMENTAL config option and will likely change.
+    org: my-oranization
+```
+
+[github-oauth2]: https://github.com/settings/applications/new

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Standards-based token responses allows applications to interact with any OpenID 
 * [gRPC API](Documentation/api.md)
 * Identity provider logins
   * [LDAP](Documentation/ldap-connector.md)
+  * [GitHub](Documentation/github-connector.md)
 * Client libraries
   * [Go][go-oidc]
 

--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -75,7 +75,7 @@ func (c *oidcConnector) Close() error {
 	return nil
 }
 
-func (c *oidcConnector) LoginURL(callbackURL, state string) (string, error) {
+func (c *oidcConnector) LoginURL(s connector.Scopes, callbackURL, state string) (string, error) {
 	if c.redirectURI != callbackURL {
 		return "", fmt.Errorf("expected callback URL did not match the URL in the config")
 	}
@@ -94,7 +94,7 @@ func (e *oauth2Error) Error() string {
 	return e.error + ": " + e.errorDescription
 }
 
-func (c *oidcConnector) HandleCallback(r *http.Request) (identity connector.Identity, err error) {
+func (c *oidcConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
 	q := r.URL.Query()
 	if errType := q.Get("error"); errType != "" {
 		return identity, &oauth2Error{errType, q.Get("error_description")}

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/dex/connector"
 	"github.com/coreos/dex/storage"
 )
 
@@ -92,6 +93,19 @@ const (
 	responseTypeToken   = "token"    // Implicit flow for frontend apps.
 	responseTypeIDToken = "id_token" // ID Token in url fragment
 )
+
+func parseScopes(scopes []string) connector.Scopes {
+	var s connector.Scopes
+	for _, scope := range scopes {
+		switch scope {
+		case scopeOfflineAccess:
+			s.OfflineAccess = true
+		case scopeGroups:
+			s.Groups = true
+		}
+	}
+	return s
+}
 
 type audience []string
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -662,7 +662,6 @@ func TestCrossClientScopes(t *testing.T) {
 func TestPasswordDB(t *testing.T) {
 	s := memory.New()
 	conn := newPasswordDB(s)
-	defer conn.Close()
 
 	pw := "hi"
 
@@ -712,7 +711,7 @@ func TestPasswordDB(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		ident, valid, err := conn.Login(tc.username, tc.password)
+		ident, valid, err := conn.Login(context.Background(), connector.Scopes{}, tc.username, tc.password)
 		if err != nil {
 			if !tc.wantErr {
 				t.Errorf("%s: %v", tc.name, err)


### PR DESCRIPTION
This is a work in progress to add a RefreshConnector interface so refresh token requests query the upstream identity provider before returning.

Lots of testing needed.

Closes #693
Updates #678