### PR TITLE
cmd/example-app: use a non-empty state

### DIFF
--- a/cmd/example-app/main.go
+++ b/cmd/example-app/main.go
@@ -23,6 +23,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const exampleAppState = "I wish to wash my irish wristwatch"
+
 type app struct {
 	clientID     string
 	clientSecret string
@@ -241,9 +243,9 @@ func (a *app) handleLogin(w http.ResponseWriter, r *http.Request) {
 	scopes = append(scopes, "openid", "profile", "email")
 	if a.offlineAsScope {
 		scopes = append(scopes, "offline_access")
-		authCodeURL = a.oauth2Config(scopes).AuthCodeURL("")
+		authCodeURL = a.oauth2Config(scopes).AuthCodeURL(exampleAppState)
 	} else {
-		authCodeURL = a.oauth2Config(scopes).AuthCodeURL("", oauth2.AccessTypeOffline)
+		authCodeURL = a.oauth2Config(scopes).AuthCodeURL(exampleAppState, oauth2.AccessTypeOffline)
 	}
 	http.Redirect(w, r, authCodeURL, http.StatusSeeOther)
 }
@@ -251,6 +253,11 @@ func (a *app) handleLogin(w http.ResponseWriter, r *http.Request) {
 func (a *app) handleCallback(w http.ResponseWriter, r *http.Request) {
 	if errMsg := r.FormValue("error"); errMsg != "" {
 		http.Error(w, errMsg+": "+r.FormValue("error_description"), http.StatusBadRequest)
+		return
+	}
+
+	if state := r.FormValue("state"); state != exampleAppState {
+		http.Error(w, fmt.Sprintf("expected state %q got %q", exampleAppState, state), http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
Use a non-empty state in the example-app to ensure dex is properly
preserving the state for the code flow.

Updates #712

cc @rithujohn191 