### PR TITLE
*: update vendored go-oidc

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: c3530f2a60a64c2efc4c3ac499fcd15f79de2a532715ba2b9841c1d404942b2e
-updated: 2016-11-17T15:18:56.701287533-08:00
+hash: 773c45cb2136423f907496cc1ba67e0c58b35e237b15b0d5f212dce598265442
+updated: 2016-12-01T13:12:54.401738528-08:00
 imports:
 - name: github.com/cockroachdb/cockroach-go
   version: 31611c0501c812f437d4861d87d117053967c955
   subpackages:
   - crdb
 - name: github.com/coreos/go-oidc
-  version: 5a7f09ab5787e846efa7f56f4a08b6d6926d08c4
+  version: dedb650fb29c39c2f21aa88c1e4cec66da8754d1
 - name: github.com/ghodss/yaml
   version: bea76d6a4713e18b7f5321a2b020738552def3ea
 - name: github.com/go-sql-driver/mysql

--- a/glide.yaml
+++ b/glide.yaml
@@ -51,7 +51,7 @@ import:
   - bcrypt
 
 - package: github.com/coreos/go-oidc
-  version: 5a7f09ab5787e846efa7f56f4a08b6d6926d08c4
+  version: dedb650fb29c39c2f21aa88c1e4cec66da8754d1
 - package: github.com/pquerna/cachecontrol
   version: c97913dcbd76de40b051a9b4cd827f7eaeb7a868
 - package: golang.org/x/oauth2

--- a/vendor/github.com/coreos/go-oidc/.travis.yml
+++ b/vendor/github.com/coreos/go-oidc/.travis.yml
@@ -5,7 +5,7 @@ go:
   - 1.6.3
 
 install:
- - go get -v -t github.com/coreos/go-oidc
+ - go get -v -t github.com/coreos/go-oidc/...
  - go get golang.org/x/tools/cmd/cover
  - go get github.com/golang/lint/golint
 

--- a/vendor/github.com/coreos/go-oidc/jose/jwk.go
+++ b/vendor/github.com/coreos/go-oidc/jose/jwk.go
@@ -104,7 +104,7 @@ func encodeExponent(e int) string {
 			break
 		}
 	}
-	return base64.URLEncoding.EncodeToString(b[idx:])
+	return base64.RawURLEncoding.EncodeToString(b[idx:])
 }
 
 // Turns a URL encoded modulus of a key into a big int.
@@ -119,7 +119,7 @@ func decodeModulus(n string) (*big.Int, error) {
 }
 
 func encodeModulus(n *big.Int) string {
-	return base64.URLEncoding.EncodeToString(n.Bytes())
+	return base64.RawURLEncoding.EncodeToString(n.Bytes())
 }
 
 // decodeBase64URLPaddingOptional decodes Base64 whether there is padding or not.

--- a/vendor/github.com/coreos/go-oidc/key/key_test.go
+++ b/vendor/github.com/coreos/go-oidc/key/key_test.go
@@ -76,7 +76,7 @@ func TestPublicKeyMarshalJSON(t *testing.T) {
 		Modulus:  big.NewInt(int64(17)),
 		Exponent: 65537,
 	}
-	want := `{"kid":"foo","kty":"RSA","alg":"RS256","use":"sig","e":"AQAB","n":"EQ=="}`
+	want := `{"kid":"foo","kty":"RSA","alg":"RS256","use":"sig","e":"AQAB","n":"EQ"}`
 	pubKey := NewPublicKey(k)
 	gotBytes, err := pubKey.MarshalJSON()
 	if err != nil {

--- a/vendor/github.com/coreos/go-oidc/oidc/provider.go
+++ b/vendor/github.com/coreos/go-oidc/oidc/provider.go
@@ -567,7 +567,7 @@ func (n *pcsStepNext) step(fn pcsStepFunc) (next pcsStepper) {
 		next = &pcsStepNext{aft: ttl}
 	} else {
 		next = &pcsStepRetry{aft: time.Second}
-		log.Printf("go-oidc: provider config sync falied, retyring in %v: %v", next.after(), err)
+		log.Printf("go-oidc: provider config sync failed, retrying in %v: %v", next.after(), err)
 	}
 	return
 }
@@ -586,7 +586,7 @@ func (r *pcsStepRetry) step(fn pcsStepFunc) (next pcsStepper) {
 		next = &pcsStepNext{aft: ttl}
 	} else {
 		next = &pcsStepRetry{aft: timeutil.ExpBackoff(r.aft, time.Minute)}
-		log.Printf("go-oidc: provider config sync falied, retyring in %v: %v", next.after(), err)
+		log.Printf("go-oidc: provider config sync failed, retrying in %v: %v", next.after(), err)
 	}
 	return
 }

--- a/vendor/github.com/coreos/go-oidc/test
+++ b/vendor/github.com/coreos/go-oidc/test
@@ -9,7 +9,7 @@ LINTABLE=$( go list -tags=golint -f '
   {{ range $i, $file := .TestGoFiles -}}
     {{ $file }} {{ end }}' github.com/coreos/go-oidc )
 
-go test -v -i -race github.com/coreos/go-oidc
-go test -v -race github.com/coreos/go-oidc
+go test -v -i -race github.com/coreos/go-oidc/...
+go test -v -race github.com/coreos/go-oidc/...
 golint $LINTABLE
-go vet github.com/coreos/go-oidc
+go vet github.com/coreos/go-oidc/...


### PR DESCRIPTION
Includes fixes for a panic when using HTTP/2[0] and some HTTPs calls
not actually using their passed context[1].

[0] coreos/go-oidc#117
[1] coreos/go-oidc#119