### PR TITLE
v1: don't deploy on merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,15 +36,6 @@ script:
   - ./build-docker
   - ./build-docker clean
 
-deploy:
-  provider: script
-  script: scripts/deploy
-  skip_cleanup: true
-  on:
-    branch: master
-    go: '1.6.2'
-    condition: "$TRAVIS_PULL_REQUEST = false"
-
 notifications:
   email: false
 


### PR DESCRIPTION
We don't want to clutter the Quay repo with non-release tags,
particularly if they're not for the master branch.