### PR TITLE
*: check go version before building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ LD_FLAGS="-w -X $(REPO_PATH)/version.Version=$(VERSION)"
 
 build: bin/dex bin/example-app
 
-bin/dex: FORCE
+bin/dex: check-go-version
 	@go install -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/dex
 
-bin/example-app: FORCE
+bin/example-app: check-go-version
 	@go install -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/example-app
 
 .PHONY: release-binary
@@ -87,6 +87,10 @@ bin/protoc: scripts/get-protoc
 
 bin/protoc-gen-go:
 	@go install -v $(REPO_PATH)/vendor/github.com/golang/protobuf/protoc-gen-go
+
+.PHONY: check-go-version
+check-go-version:
+	@./scripts/check-go-version
 
 clean: clean-release
 	@rm -rf bin/

--- a/scripts/check-go-version
+++ b/scripts/check-go-version
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -e
+
+VERSION=$( go version )
+
+# For development versions of Go, these will be empty.
+MAJOR_GOVERSION=$( echo -n "$VERSION" | grep -o 'go1\.[0-9]' || true )
+FULL_GOVERSION=$( echo -n "$VERSION" | grep -o 'go1\.[0-9|\.]*' || true )
+
+# The list of unsupported major go versions.
+UNSUPPORTED=( "go1.0" "go1.1" "go1.2" "go1.3" "go1.4" "go1.5" "go1.6" )
+
+# Minor go verisons which have known security vulnerabilities. Refuse to build with these.
+#
+# There aren't any security issues that impact dex in 1.7 but minor versions should be
+# added here later if they do have issues. 
+KNOWN_INSECURE=( )
+
+for V in "${UNSUPPORTED[@]}"; do
+    if [ "$V" = "$MAJOR_GOVERSION" ]; then
+        >&2 echo "ERROR: dex requires Go version 1.7+. Please update your Go installation: https://golang.org/dl/" 
+        exit 2
+    fi
+done
+
+for V in "${KNOWN_INSECURE[@]}"; do
+    if [ "$V" = "$FULL_GOVERSION" ]; then
+        >&2 echo "Go version ${V} has known security vulnerabilities which impact dex. Please update your Go verison."
+        exit 2
+    fi
+done
+


### PR DESCRIPTION
Add a script to check the Go version before building dex. This
gives a nice error message rather than just failing to compile.

With changes:

    $ go version
    go version go1.6.4 linux/amd64
    $ make
    ERROR: dex requires Go version 1.7+. Please update your Go installation: https://golang.org/dl/
    Makefile:93: recipe for target 'check-go-version' failed
    make: *** [check-go-version] Error 2

Checks only added for building the actual binary, not tests, since
this is aimed at users just starting off with the project.

Closes #738

cc @rithujohn191 