### PR TITLE
server: wrap the default server.now function to always return UTC

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -174,7 +174,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 
 	now := c.Now
 	if now == nil {
-		now = time.Now
+		now = func() time.Time { return time.Now().UTC() }
 	}
 
 	s := &Server{


### PR DESCRIPTION
This change was my resolution to the issue described in #745 