### PR TITLE
build fails

### DIFF
--- a/scripts/check-go-version
+++ b/scripts/check-go-version
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
I followed https://github.com/coreos/dex/blob/master/Documentation/getting-started.md
and make fails, because scripts/check-go-version references the wron shell in it's shebang.
sh has no arrays