### PR TITLE
Fixed refresh tokens to work correctly with kubernetes storage

### DIFF
--- a/storage/kubernetes/storage.go
+++ b/storage/kubernetes/storage.go
@@ -162,11 +162,12 @@ func (cli *client) CreateRefresh(r storage.RefreshToken) error {
 			Name:      r.RefreshToken,
 			Namespace: cli.namespace,
 		},
-		ClientID:    r.ClientID,
-		ConnectorID: r.ConnectorID,
-		Scopes:      r.Scopes,
-		Nonce:       r.Nonce,
-		Claims:      fromStorageClaims(r.Claims),
+		ClientID:      r.ClientID,
+		ConnectorID:   r.ConnectorID,
+		Scopes:        r.Scopes,
+		Nonce:         r.Nonce,
+		Claims:        fromStorageClaims(r.Claims),
+		ConnectorData: r.ConnectorData,
 	}
 	return cli.post(resourceRefreshToken, refresh)
 }
@@ -243,12 +244,13 @@ func (cli *client) GetRefresh(id string) (storage.RefreshToken, error) {
 		return storage.RefreshToken{}, err
 	}
 	return storage.RefreshToken{
-		RefreshToken: r.ObjectMeta.Name,
-		ClientID:     r.ClientID,
-		ConnectorID:  r.ConnectorID,
-		Scopes:       r.Scopes,
-		Nonce:        r.Nonce,
-		Claims:       toStorageClaims(r.Claims),
+		RefreshToken:  r.ObjectMeta.Name,
+		ClientID:      r.ClientID,
+		ConnectorID:   r.ConnectorID,
+		Scopes:        r.Scopes,
+		Nonce:         r.Nonce,
+		Claims:        toStorageClaims(r.Claims),
+		ConnectorData: r.ConnectorData,
 	}, nil
 }
 

--- a/storage/kubernetes/types.go
+++ b/storage/kubernetes/types.go
@@ -367,8 +367,9 @@ type RefreshToken struct {
 
 	Nonce string `json:"nonce,omitempty"`
 
-	Claims      Claims `json:"claims,omitempty"`
-	ConnectorID string `json:"connectorID,omitempty"`
+	Claims        Claims `json:"claims,omitempty"`
+	ConnectorID   string `json:"connectorID,omitempty"`
+	ConnectorData []byte `json:"connectorData,omitempty"`
 }
 
 // RefreshList is a list of refresh tokens.


### PR DESCRIPTION
It was missing connectorData for RefreshToken under Kubernetes storage. Fixed this to allow refresh to work correctly without 500 server error.