### PR TITLE
server: fixes for the implicit and hybrid flow

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -144,12 +144,23 @@ func (s *Server) discoveryHandler() (http.Handler, error) {
 
 // handleAuthorization handles the OAuth2 auth endpoint.
 func (s *Server) handleAuthorization(w http.ResponseWriter, r *http.Request) {
-	authReq, err := s.parseAuthorizationRequest(s.supportedResponseTypes, r)
+	authReq, err := s.parseAuthorizationRequest(r)
 	if err != nil {
 		s.logger.Errorf("Failed to parse authorization request: %v", err)
-		s.renderError(w, http.StatusInternalServerError, "Failed to connect to the database.")
+		if handler, ok := err.Handle(); ok {
+			// client_id and redirect_uri checked out and we can redirect back to
+			// the client with the error.
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		// Otherwise render the error to the user.
+		//
+		// TODO(ericchiang): Should we just always render the error?
+		s.renderError(w, err.Status(), err.Error())
 		return
 	}
+
 	authReq.Expiry = s.now().Add(time.Minute * 30)
 	if err := s.storage.CreateAuthRequest(authReq); err != nil {
 		s.logger.Errorf("Failed to create authorization request: %v", err)
@@ -397,12 +408,25 @@ func (s *Server) sendCodeResponse(w http.ResponseWriter, r *http.Request, authRe
 		s.renderError(w, http.StatusInternalServerError, "Invalid redirect URI.")
 		return
 	}
-	q := u.Query()
+
+	var (
+		// Was the initial request using the implicit or hybrid flow instead of
+		// the "normal" code flow?
+		implicitOrHybrid = false
+
+		// Only present in hybrid or code flow. code.ID == "" if this is not set.
+		code storage.AuthCode
+
+		// ID token returned immediately if the response_type includes "id_token".
+		// Only valid for implicit and hybrid flows.
+		idToken       string
+		idTokenExpiry time.Time
+	)
 
 	for _, responseType := range authReq.ResponseTypes {
 		switch responseType {
 		case responseTypeCode:
-			code := storage.AuthCode{
+			code = storage.AuthCode{
 				ID:            storage.NewID(),
 				ClientID:      authReq.ClientID,
 				ConnectorID:   authReq.ConnectorID,
@@ -419,32 +443,73 @@ func (s *Server) sendCodeResponse(w http.ResponseWriter, r *http.Request, authRe
 				return
 			}
 
+			// Implicit and hybrid flows that try to use the OOB redirect URI are
+			// rejected earlier. If we got here we're using the code flow.
 			if authReq.RedirectURI == redirectURIOOB {
 				if err := s.templates.oob(w, code.ID); err != nil {
 					s.logger.Errorf("Server template error: %v", err)
 				}
 				return
 			}
-			q.Set("code", code.ID)
 		case responseTypeToken:
-			idToken, expiry, err := s.newIDToken(authReq.ClientID, authReq.Claims, authReq.Scopes, authReq.Nonce)
+			implicitOrHybrid = true
+		case responseTypeIDToken:
+			implicitOrHybrid = true
+			var err error
+			idToken, idTokenExpiry, err = s.newIDToken(authReq.ClientID, authReq.Claims, authReq.Scopes, authReq.Nonce)
 			if err != nil {
 				s.logger.Errorf("failed to create ID token: %v", err)
 				s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
 				return
 			}
-			v := url.Values{}
-			v.Set("access_token", storage.NewID())
-			v.Set("token_type", "bearer")
-			v.Set("id_token", idToken)
-			v.Set("state", authReq.State)
-			v.Set("expires_in", strconv.Itoa(int(expiry.Sub(s.now()).Seconds())))
-			u.Fragment = v.Encode()
 		}
 	}
 
-	q.Set("state", authReq.State)
-	u.RawQuery = q.Encode()
+	if implicitOrHybrid {
+		v := url.Values{}
+		v.Set("access_token", storage.NewID())
+		v.Set("token_type", "bearer")
+		v.Set("state", authReq.State)
+		if idToken != "" {
+			v.Set("id_token", idToken)
+			// The hybrid flow with only "code token" or "code id_token" doesn't return an
+			// "expires_in" value. If "code" wasn't provided, indicating the implicit flow,
+			// don't add it.
+			//
+			// https://openid.net/specs/openid-connect-core-1_0.html#HybridAuthResponse
+			if code.ID == "" {
+				v.Set("expires_in", strconv.Itoa(int(idTokenExpiry.Sub(s.now()).Seconds())))
+			}
+		}
+		if code.ID != "" {
+			v.Set("code", code.ID)
+		}
+
+		// Implicit and hybrid flows return their values as part of the fragment.
+		//
+		//   HTTP/1.1 303 See Other
+		//   Location: https://client.example.org/cb#
+		//     access_token=SlAV32hkKG
+		//     &token_type=bearer
+		//     &id_token=eyJ0 ... NiJ9.eyJ1c ... I6IjIifX0.DeWt4Qu ... ZXso
+		//     &expires_in=3600
+		//     &state=af0ifjsldkj
+		//
+		u.Fragment = v.Encode()
+	} else {
+		// The code flow add values to the URL query.
+		//
+		//   HTTP/1.1 303 See Other
+		//   Location: https://client.example.org/cb?
+		//     code=SplxlOBeZQQYbYS6WxSbIA
+		//     &state=af0ifjsldkj
+		//
+		q := u.Query()
+		q.Set("code", code.ID)
+		q.Set("state", authReq.State)
+		u.RawQuery = q.Encode()
+	}
+
 	http.Redirect(w, r, u.String(), http.StatusSeeOther)
 }
 

--- a/server/oauth2_test.go
+++ b/server/oauth2_test.go
@@ -1,1 +1,150 @@
 package server
+
+import (
+	"context"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/coreos/dex/storage"
+)
+
+func TestParseAuthorizationRequest(t *testing.T) {
+	tests := []struct {
+		name                   string
+		clients                []storage.Client
+		supportedResponseTypes []string
+
+		queryParams map[string]string
+
+		wantErr bool
+	}{
+		{
+			name: "normal request",
+			clients: []storage.Client{
+				{
+					ID:           "foo",
+					RedirectURIs: []string{"https://example.com/foo"},
+				},
+			},
+			supportedResponseTypes: []string{"code"},
+			queryParams: map[string]string{
+				"client_id":     "foo",
+				"redirect_uri":  "https://example.com/foo",
+				"response_type": "code",
+				"scope":         "openid email profile",
+			},
+		},
+		{
+			name: "invalid client id",
+			clients: []storage.Client{
+				{
+					ID:           "foo",
+					RedirectURIs: []string{"https://example.com/foo"},
+				},
+			},
+			supportedResponseTypes: []string{"code"},
+			queryParams: map[string]string{
+				"client_id":     "bar",
+				"redirect_uri":  "https://example.com/foo",
+				"response_type": "code",
+				"scope":         "openid email profile",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid redirect uri",
+			clients: []storage.Client{
+				{
+					ID:           "bar",
+					RedirectURIs: []string{"https://example.com/bar"},
+				},
+			},
+			supportedResponseTypes: []string{"code"},
+			queryParams: map[string]string{
+				"client_id":     "bar",
+				"redirect_uri":  "https://example.com/foo",
+				"response_type": "code",
+				"scope":         "openid email profile",
+			},
+			wantErr: true,
+		},
+		{
+			name: "implicit flow",
+			clients: []storage.Client{
+				{
+					ID:           "bar",
+					RedirectURIs: []string{"https://example.com/bar"},
+				},
+			},
+			supportedResponseTypes: []string{"code", "id_token", "token"},
+			queryParams: map[string]string{
+				"client_id":     "bar",
+				"redirect_uri":  "https://example.com/bar",
+				"response_type": "code id_token",
+				"scope":         "openid email profile",
+			},
+		},
+		{
+			name: "unsupported response type",
+			clients: []storage.Client{
+				{
+					ID:           "bar",
+					RedirectURIs: []string{"https://example.com/bar"},
+				},
+			},
+			supportedResponseTypes: []string{"code"},
+			queryParams: map[string]string{
+				"client_id":     "bar",
+				"redirect_uri":  "https://example.com/bar",
+				"response_type": "code id_token",
+				"scope":         "openid email profile",
+			},
+			wantErr: true,
+		},
+		{
+			name: "only token response type",
+			clients: []storage.Client{
+				{
+					ID:           "bar",
+					RedirectURIs: []string{"https://example.com/bar"},
+				},
+			},
+			supportedResponseTypes: []string{"code", "id_token", "token"},
+			queryParams: map[string]string{
+				"client_id":     "bar",
+				"redirect_uri":  "https://example.com/bar",
+				"response_type": "token",
+				"scope":         "openid email profile",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			httpServer, server := newTestServer(ctx, t, func(c *Config) {
+				c.SupportedResponseTypes = tc.supportedResponseTypes
+				c.Storage = storage.WithStaticClients(c.Storage, tc.clients)
+			})
+			defer httpServer.Close()
+
+			params := url.Values{}
+			for k, v := range tc.queryParams {
+				params.Set(k, v)
+			}
+
+			req := httptest.NewRequest("GET", httpServer.URL+"/auth?"+params.Encode(), nil)
+			_, err := server.parseAuthorizationRequest(req)
+			if err != nil && !tc.wantErr {
+				t.Errorf("%s: %v", tc.name, err)
+			}
+			if err == nil && tc.wantErr {
+				t.Errorf("%s: expected error", tc.name)
+			}
+		}()
+	}
+}

--- a/server/rotation.go
+++ b/server/rotation.go
@@ -130,6 +130,7 @@ func (k keyRotater) rotate() error {
 
 		// Remove expired verification keys.
 		i := 0
+
 		for _, key := range keys.VerificationKeys {
 			if !key.Expiry.After(tNow) {
 				keys.VerificationKeys[i] = key

--- a/server/server.go
+++ b/server/server.go
@@ -159,7 +159,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	supported := make(map[string]bool)
 	for _, respType := range c.SupportedResponseTypes {
 		switch respType {
-		case responseTypeCode, responseTypeToken:
+		case responseTypeCode, responseTypeIDToken, responseTypeToken:
 		default:
 			return nil, fmt.Errorf("unsupported response_type %q", respType)
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -510,7 +510,7 @@ func TestOAuth2ImplicitFlow(t *testing.T) {
 
 	httpServer, s := newTestServer(ctx, t, func(c *Config) {
 		// Enable support for the implicit flow.
-		c.SupportedResponseTypes = []string{"code", "token"}
+		c.SupportedResponseTypes = []string{"code", "token", "id_token"}
 	})
 	defer httpServer.Close()
 
@@ -553,7 +553,7 @@ func TestOAuth2ImplicitFlow(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
-		u := oauth2Config.AuthCodeURL(state, oauth2.SetAuthURLParam("response_type", "token"), oidc.Nonce(nonce))
+		u := oauth2Config.AuthCodeURL(state, oauth2.SetAuthURLParam("response_type", "id_token token"), oidc.Nonce(nonce))
 		http.Redirect(w, r, u, http.StatusSeeOther)
 	}))
 


### PR DESCRIPTION
Accept the following response_type for the implicit flow:

    id_token
    token id_token

And the following for hybrid flow

    code id_token
    code token
    code token id_token

This corrects the previous behavior of the implicit flow, which
only accepted "token" (now correctly rejected).

cc @rithujohn191 @xeonx 

@xeonx can you see if this branch works with your client?

closes #761