### PR TITLE
server: add at_hash claim support

### DIFF
--- a/server/oauth2_test.go
+++ b/server/oauth2_test.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"testing"
 
+	jose "gopkg.in/square/go-jose.v2"
+
 	"github.com/coreos/dex/storage"
 )
 
@@ -146,5 +148,22 @@ func TestParseAuthorizationRequest(t *testing.T) {
 				t.Errorf("%s: expected error", tc.name)
 			}
 		}()
+	}
+}
+
+const (
+	// at_hash value and access_token returned by Google.
+	googleAccessTokenHash = "piwt8oCH-K2D9pXlaS1Y-w"
+	googleAccessToken     = "ya29.CjHSA1l5WUn8xZ6HanHFzzdHdbXm-14rxnC7JHch9eFIsZkQEGoWzaYG4o7k5f6BnPLj"
+	googleSigningAlg      = jose.RS256
+)
+
+func TestAccessTokenHash(t *testing.T) {
+	atHash, err := accessTokenHash(googleSigningAlg, googleAccessToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if atHash != googleAccessTokenHash {
+		t.Errorf("expected %q got %q", googleAccessTokenHash, atHash)
 	}
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,13 +1,9 @@
 package storage
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"encoding/base32"
 	"errors"
-	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -287,39 +283,4 @@ type Keys struct {
 	//
 	// For caching purposes, implementations MUST NOT update keys before this time.
 	NextRotation time.Time
-}
-
-// Sign creates a JWT using the signing key.
-func (k Keys) Sign(payload []byte) (jws string, err error) {
-	if k.SigningKey == nil {
-		return "", fmt.Errorf("no key to sign payload with")
-	}
-	signingKey := jose.SigningKey{Key: k.SigningKey}
-
-	switch key := k.SigningKey.Key.(type) {
-	case *rsa.PrivateKey:
-		// TODO(ericchiang): Allow different cryptographic hashes.
-		signingKey.Algorithm = jose.RS256
-	case *ecdsa.PrivateKey:
-		switch key.Params() {
-		case elliptic.P256().Params():
-			signingKey.Algorithm = jose.ES256
-		case elliptic.P384().Params():
-			signingKey.Algorithm = jose.ES384
-		case elliptic.P521().Params():
-			signingKey.Algorithm = jose.ES512
-		default:
-			return "", errors.New("unsupported ecdsa curve")
-		}
-	}
-
-	signer, err := jose.NewSigner(signingKey, &jose.SignerOptions{})
-	if err != nil {
-		return "", fmt.Errorf("new signier: %v", err)
-	}
-	signature, err := signer.Sign(payload)
-	if err != nil {
-		return "", fmt.Errorf("signing payload: %v", err)
-	}
-	return signature.CompactSerialize()
 }


### PR DESCRIPTION
The "at_hash" claim, which provides hash verification for the
"access_token," is a required claim for implicit and hybrid flow
requests. Previously we did not include it (against spec). This
PR implements the "at_hash" logic and adds the claim to all
responses.

As a cleanup, it also moves some JOSE signing logic out of the
storage package and into the server package.

For details see:

https://openid.net/specs/openid-connect-core-1_0.html#ImplicitIDToken

closes #771