### PR TITLE
Support for environment variables support in config files

### DIFF
--- a/connector/ldap/ldap.go
+++ b/connector/ldap/ldap.go
@@ -204,7 +204,7 @@ func (c *Config) OpenConnector(logger logrus.FieldLogger) (interface {
 	}
 	groupSearchScope, ok := parseScope(c.GroupSearch.Scope)
 	if !ok {
-		return nil, fmt.Errorf("userSearch.Scope unknown value %q", c.GroupSearch.Scope)
+		return nil, fmt.Errorf("groupSearch.Scope unknown value %q", c.GroupSearch.Scope)
 	}
 	return &ldapConnector{*c, userSearchScope, groupSearchScope, tlsConfig, logger}, nil
 }


### PR DESCRIPTION
This small pr enables one to use the ${VAR} notation within the yaml configuration file. As we run dex in containers, being able to use environment variables as configuration is pretty useful for us.  Would this functionality make sense for dex? If so I could make a more complete version of this pr and submit it again. Thanks!
