### PR TITLE
cmd/dex: make connector name field mandatory in dex configuration.

### DIFF
--- a/Documentation/github-connector.md
+++ b/Documentation/github-connector.md
@@ -15,7 +15,9 @@ The following is an example of a configuration for `examples/config-dev.yaml`:
 ```yaml
 connectors:
 - type: github
+  # Required field for connector id.
   id: github
+  # Required field for connector name.
   name: GitHub
   config:
     # Credentials can be string literals or pulled from the environment.

--- a/Documentation/ldap-connector.md
+++ b/Documentation/ldap-connector.md
@@ -24,7 +24,9 @@ The following is an example config file that can be used by the LDAP connector t
 ```yaml
 connectors:
 - type: ldap
+  # Required field for connector id.
   id: ldap
+  # Required field for connector name.
   name: LDAP
   config:
     # Host and optional port of the LDAP server in the form "host:port".
@@ -189,6 +191,7 @@ The following configuration will allow the LDAP connector to search a FreeIPA di
 connectors:
 - type: ldap
   id: ldap
+  name: LDAP
   config:
     # host and port of the LDAP server in form "host:port".
     host: freeipa.example.com:636

--- a/Documentation/saml-connector.md
+++ b/Documentation/saml-connector.md
@@ -19,7 +19,10 @@ The connector doesn't support refresh tokens since the SAML 2.0 protocol doesn't
 ```yaml
 connectors:
 - type: samlExperimental # will be changed to "saml" later without support for the "samlExperimental" value
+  # Required field for connector id.
   id: saml
+  # Required field for connector name.
+  name: SAML
   config:
     # Issuer used for validating the SAML response.
     issuer: https://saml.example.com

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -136,6 +136,9 @@ func serve(cmd *cobra.Command, args []string) error {
 		if conn.Config == nil {
 			return fmt.Errorf("invalid config: no config field for connector %q", conn.ID)
 		}
+		if conn.Name == "" {
+			return fmt.Errorf("invalid config: no Name field for connector %q", conn.ID)
+		}
 		logger.Infof("config connector: %s", conn.ID)
 
 		connectorLogger := logger.WithField("connector", conn.Name)


### PR DESCRIPTION
Addresses one of the many issues detailed in #681 