### PR TITLE
{web,server}: use html/template and reduce use of auth request ID

### DIFF
--- a/server/templates.go
+++ b/server/templates.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"html/template"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"text/template"
 )
 
 const (
@@ -181,23 +181,20 @@ func (n byName) Len() int           { return len(n) }
 func (n byName) Less(i, j int) bool { return n[i].Name < n[j].Name }
 func (n byName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
 
-func (t *templates) login(w http.ResponseWriter, connectors []connectorInfo, authReqID string) error {
+func (t *templates) login(w http.ResponseWriter, connectors []connectorInfo) error {
 	sort.Sort(byName(connectors))
-
 	data := struct {
 		Connectors []connectorInfo
-		AuthReqID  string
-	}{connectors, authReqID}
+	}{connectors}
 	return renderTemplate(w, t.loginTmpl, data)
 }
 
-func (t *templates) password(w http.ResponseWriter, authReqID, callback, lastUsername string, lastWasInvalid bool) error {
+func (t *templates) password(w http.ResponseWriter, postURL, lastUsername string, lastWasInvalid bool) error {
 	data := struct {
-		AuthReqID string
-		PostURL   string
-		Username  string
-		Invalid   bool
-	}{authReqID, string(callback), lastUsername, lastWasInvalid}
+		PostURL  string
+		Username string
+		Invalid  bool
+	}{postURL, lastUsername, lastWasInvalid}
 	return renderTemplate(w, t.passwordTmpl, data)
 }
 

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -5,7 +5,7 @@
   <div>
     {{ range $c := .Connectors }}
       <div class="theme-form-row">
-        <a href="{{ $c.URL }}?req={{ $.AuthReqID }}" target="_self">
+        <a href="{{ $c.URL }}" target="_self">
           <button class="dex-btn theme-btn-provider">
             <span class="dex-btn-icon dex-btn-icon--{{ $c.ID }}"></span>
             <span class="dex-btn-text">Log in with {{ $c.Name }}</span>

--- a/web/templates/password.html
+++ b/web/templates/password.html
@@ -15,7 +15,6 @@
       </div>
 	  <input tabindex="2" required id="password" name="password" type="password" class="theme-form-input" placeholder="password" {{ if .Invalid }} autofocus {{ end }}/>
     </div>
-    <input type="hidden" name="req" value="{{ .AuthReqID }}"/>
 
     {{ if .Invalid }}
       <div class="dex-error-box">


### PR DESCRIPTION
Switch from using "text/template" to "html/template", which provides
basic XSS preventions. We haven't identified any particular place
where unsanitized user data is rendered to the frontend. This is
just a preventative step.

At the same time, make more templates take pure URL instead of
forming an URL themselves using an "authReqID" argument. This will
help us stop using the auth req ID in certain places, preventing
garbage collection from killing login flows that wait too long at
the login screen.

Also increase the login session window (time between initial
redirect and the user logging in) from 30 minutes to 24 hours,
and display a more helpful error message when the session expires.

How to test:

1. Spin up dex and example-app with examples/config-dev.yaml.
2. Login through both the password prompt and the direct redirect.
3. Edit examples/config-dev.yaml removing the "connectors" section.
4. Ensure you can still login with a password.

(email/password is "admin@example.com" and "password")

Closes https://github.com/coreos/dex/issues/687
Updates https://github.com/coreos/dex/issues/646

cc @rithujohn191 (no hurry)