### PR TITLE
storage: Surface "already exists" errors.

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -53,8 +53,10 @@ func (d dexAPI) CreateClient(ctx context.Context, req *api.CreateClientReq) (*ap
 		LogoURL:      req.Client.LogoUrl,
 	}
 	if err := d.s.CreateClient(c); err != nil {
+		if err == storage.ErrAlreadyExists {
+			return &api.CreateClientResp{AlreadyExists: true}, nil
+		}
 		d.logger.Errorf("api: failed to create client: %v", err)
-		// TODO(ericchiang): Surface "already exists" errors.
 		return nil, fmt.Errorf("create client: %v", err)
 	}
 
@@ -109,6 +111,9 @@ func (d dexAPI) CreatePassword(ctx context.Context, req *api.CreatePasswordReq) 
 		UserID:   req.Password.UserId,
 	}
 	if err := d.s.CreatePassword(p); err != nil {
+		if err == storage.ErrAlreadyExists {
+			return &api.CreatePasswordResp{AlreadyExists: true}, nil
+		}
 		d.logger.Errorf("api: failed to create password: %v", err)
 		return nil, fmt.Errorf("create password: %v", err)
 	}

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -37,8 +37,16 @@ func TestPassword(t *testing.T) {
 		Password: &p,
 	}
 
-	if _, err := serv.CreatePassword(ctx, &createReq); err != nil {
+	if resp, err := serv.CreatePassword(ctx, &createReq); err != nil || resp.AlreadyExists {
+		if resp.AlreadyExists {
+			t.Fatalf("Unable to create password since %s already exists", createReq.Password.Email)
+		}
 		t.Fatalf("Unable to create password: %v", err)
+	}
+
+	// Attempt to create a password that already exists.
+	if resp, _ := serv.CreatePassword(ctx, &createReq); !resp.AlreadyExists {
+		t.Fatalf("Created password %s twice", createReq.Password.Email)
 	}
 
 	updateReq := api.UpdatePasswordReq{

--- a/storage/sql/crud.go
+++ b/storage/sql/crud.go
@@ -125,6 +125,9 @@ func (c *conn) CreateAuthRequest(a storage.AuthRequest) error {
 		a.Expiry,
 	)
 	if err != nil {
+		if c.alreadyExistsCheck(err) {
+			return storage.ErrAlreadyExists
+		}
 		return fmt.Errorf("insert auth request: %v", err)
 	}
 	return nil
@@ -212,7 +215,14 @@ func (c *conn) CreateAuthCode(a storage.AuthCode) error {
 		a.Claims.Username, a.Claims.Email, a.Claims.EmailVerified, encoder(a.Claims.Groups),
 		a.ConnectorID, a.ConnectorData, a.Expiry,
 	)
-	return err
+
+	if err != nil {
+		if c.alreadyExistsCheck(err) {
+			return storage.ErrAlreadyExists
+		}
+		return fmt.Errorf("insert auth code: %v", err)
+	}
+	return nil
 }
 
 func (c *conn) GetAuthCode(id string) (a storage.AuthCode, err error) {
@@ -256,6 +266,9 @@ func (c *conn) CreateRefresh(r storage.RefreshToken) error {
 		r.Token, r.CreatedAt, r.LastUsed,
 	)
 	if err != nil {
+		if c.alreadyExistsCheck(err) {
+			return storage.ErrAlreadyExists
+		}
 		return fmt.Errorf("insert refresh_token: %v", err)
 	}
 	return nil
@@ -477,6 +490,9 @@ func (c *conn) CreateClient(cli storage.Client) error {
 		cli.Public, cli.Name, cli.LogoURL,
 	)
 	if err != nil {
+		if c.alreadyExistsCheck(err) {
+			return storage.ErrAlreadyExists
+		}
 		return fmt.Errorf("insert client: %v", err)
 	}
 	return nil
@@ -544,6 +560,9 @@ func (c *conn) CreatePassword(p storage.Password) error {
 		p.Email, p.Hash, p.Username, p.UserID,
 	)
 	if err != nil {
+		if c.alreadyExistsCheck(err) {
+			return storage.ErrAlreadyExists
+		}
 		return fmt.Errorf("insert password: %v", err)
 	}
 	return nil
@@ -636,6 +655,9 @@ func (c *conn) CreateOfflineSessions(s storage.OfflineSessions) error {
 		s.UserID, s.ConnID, encoder(s.Refresh),
 	)
 	if err != nil {
+		if c.alreadyExistsCheck(err) {
+			return storage.ErrAlreadyExists
+		}
 		return fmt.Errorf("insert offline session: %v", err)
 	}
 	return nil

--- a/storage/sql/migrate_test.go
+++ b/storage/sql/migrate_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Sirupsen/logrus"
+	sqlite3 "github.com/mattn/go-sqlite3"
 )
 
 func TestMigrate(t *testing.T) {
@@ -21,7 +22,15 @@ func TestMigrate(t *testing.T) {
 		Level:     logrus.DebugLevel,
 	}
 
-	c := &conn{db, flavorSQLite3, logger}
+	errCheck := func(err error) bool {
+		sqlErr, ok := err.(sqlite3.Error)
+		if !ok {
+			return false
+		}
+		return sqlErr.ExtendedCode == sqlite3.ErrConstraintUnique
+	}
+
+	c := &conn{db, flavorSQLite3, logger, errCheck}
 	for _, want := range []int{len(migrations), 0} {
 		got, err := c.migrate()
 		if err != nil {

--- a/storage/sql/sql.go
+++ b/storage/sql/sql.go
@@ -131,9 +131,10 @@ func (c *conn) translateArgs(args []interface{}) []interface{} {
 
 // conn is the main database connection.
 type conn struct {
-	db     *sql.DB
-	flavor flavor
-	logger logrus.FieldLogger
+	db                 *sql.DB
+	flavor             flavor
+	logger             logrus.FieldLogger
+	alreadyExistsCheck func(err error) bool
 }
 
 func (c *conn) Close() error {


### PR DESCRIPTION
This fixes #808.

If a database `Exec` command fails due to an "already exists" error, it is translated to a storage.ErrAlreadyExists error and propagated forward.

Added additional conformance tests to check for this scenario.
