### PR TITLE
[storage.md] Fix the ThirdPartyResource syntax

### DIFF
--- a/Documentation/storage.md
+++ b/Documentation/storage.md
@@ -20,7 +20,7 @@ apiVersion: extensions/v1beta1
 metadata:
   name: o-auth2-client.oidc.coreos.com
 versions:
-  - v1
+  - name: v1
 description: "An OAuth2 client."
 ```
 


### PR DESCRIPTION
This makes manually creating the `o-auth2-client.oidc.coreos.com` actually work.

Fixes #818 