### PR TITLE
*: make cloning to GOPATH optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 dist
 _output
+_gopath

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -2,11 +2,11 @@
 
 ## Building the dex binary
 
-Dex requires a Go installation and a GOPATH configured. For setting up a Go workspace, refer to the [official documentation][go-setup]. Clone it down the correct place, and simply type `make` to compile the dex binary.
+Building dex only requires a recent version of Go. Official install instructions for Go can be found on the [offical Go site][go-setup].
 
 ```
-$ go get github.com/coreos/dex
-$ cd $GOPATH/src/github.com/coreos/dex
+$ git clone https://github.com/coreos/dex.git
+$ cd dex
 $ make
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,37 @@
 PROJ=dex
 ORG_PATH=github.com/coreos
 REPO_PATH=$(ORG_PATH)/$(PROJ)
-export PATH := $(PWD)/bin:$(PATH)
+
+export GOBIN=$(PWD)/bin
+export GOPATH=$(shell ./scripts/gopath)
+
+# Makefile environment vairables aren't passed to "shell" calls. Need to set
+# them explicitly.
+PACKAGES=$(shell ./scripts/go list github.com/coreos/dex/... | grep -v '/vendor/')
 
 VERSION ?= $(shell ./scripts/git-version)
 
 DOCKER_REPO=quay.io/coreos/dex
 DOCKER_IMAGE=$(DOCKER_REPO):$(VERSION)
 
-$( shell mkdir -p bin )
-$( shell mkdir -p _output/images )
-$( shell mkdir -p _output/bin )
-
-user=$(shell id -u -n)
-group=$(shell id -g -n)
-
-export GOBIN=$(PWD)/bin
-# Prefer ./bin instead of system packages for things like protoc, where we want
-# to use the version dex uses, not whatever a developer has installed.
-export PATH=$(GOBIN):$(shell printenv PATH)
-export GO15VENDOREXPERIMENT=1
 
 LD_FLAGS="-w -X $(REPO_PATH)/version.Version=$(VERSION)"
 
 build: bin/dex bin/example-app bin/grpc-client
 
-bin/dex: check-go-version
+.PHONY: pre-build
+pre-build:
+	@mkdir -p bin
+	@./scripts/check-go-version
+
+bin/dex: pre-build
 	@go install -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/dex
 
-bin/example-app: check-go-version
+bin/example-app: pre-build
 	@go install -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/example-app
 
-bin/grpc-client: check-go-version
+bin/grpc-client: pre-build
 	@go install -v -ldflags $(LD_FLAGS) $(REPO_PATH)/examples/grpc-client
-
-.PHONY: release-binary
-release-binary:
-	@go build -o /go/bin/dex -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/dex
 
 .PHONY: revendor
 revendor:
@@ -44,26 +39,28 @@ revendor:
 	@glide-vc --use-lock-file --no-tests --only-code
 
 test:
-	@go test -v -i $(shell go list ./... | grep -v '/vendor/')
-	@go test -v $(shell go list ./... | grep -v '/vendor/')
+	@go test -v -i $(PACKAGES)
+	@go test -v $(PACKAGES)
 
 testrace:
-	@go test -v -i --race $(shell go list ./... | grep -v '/vendor/')
-	@go test -v --race $(shell go list ./... | grep -v '/vendor/')
+	@go test -v -i --race $(PACKAGES)
+	@go test -v --race $(PACKAGES)
 
 vet:
-	@go vet $(shell go list ./... | grep -v '/vendor/')
+	@go vet $(PACKAGES)
 
 fmt:
-	@go fmt $(shell go list ./... | grep -v '/vendor/')
+	@go fmt $(PACKAGES)
 
 lint:
-	@for package in $(shell go list ./... | grep -v '/vendor/' | grep -v '/api' | grep -v '/server/internal'); do \
+	@for package in $(shell ./scripts/go list github.com/coreos/dex/... | grep -v '/vendor/' | grep -v '/api' | grep -v '/server/internal'); do \
       golint -set_exit_status $$package $$i || exit 1; \
 	done
 
 _output/bin/dex:
 	@./scripts/docker-build
+	@user=$(shell id -u -n)
+	@group=$(shell id -g -n)
 	@sudo chown $(user):$(group) _output/bin/dex
 
 .PHONY: docker-image
@@ -74,10 +71,10 @@ docker-image: clean-release _output/bin/dex
 proto: api/api.pb.go server/internal/types.pb.go
 
 api/api.pb.go: api/api.proto bin/protoc bin/protoc-gen-go
-	@protoc --go_out=plugins=grpc:. api/*.proto
+	@./bin/protoc --go_out=plugins=grpc:. api/*.proto
 
 server/internal/types.pb.go: server/internal/types.proto bin/protoc bin/protoc-gen-go
-	@protoc --go_out=. server/internal/*.proto
+	@./bin/protoc --go_out=. server/internal/*.proto
 
 bin/protoc: scripts/get-protoc
 	@./scripts/get-protoc bin/protoc
@@ -85,12 +82,10 @@ bin/protoc: scripts/get-protoc
 bin/protoc-gen-go:
 	@go install -v $(REPO_PATH)/vendor/github.com/golang/protobuf/protoc-gen-go
 
-.PHONY: check-go-version
-check-go-version:
-	@./scripts/check-go-version
-
 clean: clean-release
 	@rm -rf bin/
+	@unlink _gopath/src/github.com/coreos/dex
+	@rm -r _gopath
 
 .PHONY: clean-release
 clean-release:

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -8,7 +8,7 @@ sudo docker run \
     -w /go/src/github.com/coreos/dex \
     golang:1.8.0-alpine \
     /bin/sh -x -c \
-    'apk add --no-cache --update alpine-sdk && make release-binary'
+    'apk add --no-cache --update alpine-sdk && go install -v github.com/coreos/dex/cmd/dex'
 
 sudo docker cp $( cat cid ):/go/bin/dex _output/bin/dex
 sudo docker rm $( cat cid )

--- a/scripts/go
+++ b/scripts/go
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+export GOPATH=$( ./scripts/gopath )
+go $@

--- a/scripts/gopath
+++ b/scripts/gopath
@@ -1,0 +1,20 @@
+#!/bin/sh -e
+
+# This script setups up a symlinked GOPATH so the project can build without
+# being cloned to an on host GOPATH. To use the GOPATH created set the
+# environment variable before calling Go tools.
+#
+#     export GOPATH=$PWD/_gopath
+#
+# The directory "_gopath" is used because Go tooling ingnores directories
+# prefixed with "_". This prevents recursively discoving the top level package.
+
+REPO=github.com/coreos/dex
+TARGET=_gopath/src/$REPO
+
+if [ ! -d $TARGET ]; then
+   mkdir -p $( dirname $TARGET )
+   ln -s $PWD $TARGET
+fi
+
+echo $PWD/_gopath


### PR DESCRIPTION
This PR causes dex to setup its own GOPATH internally using symlinks.
As a result, users should be able to clone dex to any directory and
just built or test it. E.g. this should work:

    git clone https://github.com/coreos/dex
    cd dex
    make

The on host dependencies for building dex are now just a recent Go
installation. Testing still requires golint.

This change can be tested by cloning this PR and seeing if it builds.

    git clone https://github.com/ericchiang/dex
    cd dex
    make testall