### PR TITLE
connector: Connectors without a RefreshConnector should not error out

### DIFF
--- a/connector/oidc/oidc.go
+++ b/connector/oidc/oidc.go
@@ -117,6 +117,7 @@ func (c *Config) Open(logger logrus.FieldLogger) (conn connector.Connector, err 
 
 var (
 	_ connector.CallbackConnector = (*oidcConnector)(nil)
+	_ connector.RefreshConnector  = (*oidcConnector)(nil)
 )
 
 type oidcConnector struct {
@@ -186,5 +187,10 @@ func (c *oidcConnector) HandleCallback(s connector.Scopes, r *http.Request) (ide
 		Email:         claims.Email,
 		EmailVerified: claims.EmailVerified,
 	}
+	return identity, nil
+}
+
+// Refresh is implemented for backwards compatibility, even though it's a no-op.
+func (c *oidcConnector) Refresh(ctx context.Context, s connector.Scopes, identity connector.Identity) (connector.Identity, error) {
 	return identity, nil
 }

--- a/connector/saml/saml.go
+++ b/connector/saml/saml.go
@@ -241,12 +241,6 @@ type provider struct {
 
 func (p *provider) POSTData(s connector.Scopes, id string) (action, value string, err error) {
 
-	// NOTE(ericchiang): If we can't follow up with the identity provider, can we
-	// support refresh tokens?
-	if s.OfflineAccess {
-		return "", "", fmt.Errorf("SAML does not support offline access")
-	}
-
 	r := &authnRequest{
 		ProtocolBinding: bindingPOST,
 		ID:              id,


### PR DESCRIPTION
fixes #871.

Tested this change by running the example-app with okta. The "Creating SAML data: SAML does not support offline access" error is no longer displayed. The example app does not display a refresh token on the final out put page.