### PR TITLE
storage: add connector object to backend storage.

### DIFF
--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -19,6 +19,7 @@ func New(logger logrus.FieldLogger) storage.Storage {
 		authReqs:        make(map[string]storage.AuthRequest),
 		passwords:       make(map[string]storage.Password),
 		offlineSessions: make(map[offlineSessionID]storage.OfflineSessions),
+		connectors:      make(map[string]storage.Connector),
 		logger:          logger,
 	}
 }
@@ -44,6 +45,7 @@ type memStorage struct {
 	authReqs        map[string]storage.AuthRequest
 	passwords       map[string]storage.Password
 	offlineSessions map[offlineSessionID]storage.OfflineSessions
+	connectors      map[string]storage.Connector
 
 	keys storage.Keys
 
@@ -152,6 +154,17 @@ func (s *memStorage) CreateOfflineSessions(o storage.OfflineSessions) (err error
 	return
 }
 
+func (s *memStorage) CreateConnector(connector storage.Connector) (err error) {
+	s.tx(func() {
+		if _, ok := s.connectors[connector.ID]; ok {
+			err = storage.ErrAlreadyExists
+		} else {
+			s.connectors[connector.ID] = connector
+		}
+	})
+	return
+}
+
 func (s *memStorage) GetAuthCode(id string) (c storage.AuthCode, err error) {
 	s.tx(func() {
 		var ok bool
@@ -226,6 +239,16 @@ func (s *memStorage) GetOfflineSessions(userID string, connID string) (o storage
 	return
 }
 
+func (s *memStorage) GetConnector(id string) (connector storage.Connector, err error) {
+	s.tx(func() {
+		var ok bool
+		if connector, ok = s.connectors[id]; !ok {
+			err = storage.ErrNotFound
+		}
+	})
+	return
+}
+
 func (s *memStorage) ListClients() (clients []storage.Client, err error) {
 	s.tx(func() {
 		for _, client := range s.clients {
@@ -248,6 +271,15 @@ func (s *memStorage) ListPasswords() (passwords []storage.Password, err error) {
 	s.tx(func() {
 		for _, password := range s.passwords {
 			passwords = append(passwords, password)
+		}
+	})
+	return
+}
+
+func (s *memStorage) ListConnectors() (conns []storage.Connector, err error) {
+	s.tx(func() {
+		for _, c := range s.connectors {
+			conns = append(conns, c)
 		}
 	})
 	return
@@ -320,6 +352,17 @@ func (s *memStorage) DeleteOfflineSessions(userID string, connID string) (err er
 			return
 		}
 		delete(s.offlineSessions, id)
+	})
+	return
+}
+
+func (s *memStorage) DeleteConnector(id string) (err error) {
+	s.tx(func() {
+		if _, ok := s.connectors[id]; !ok {
+			err = storage.ErrNotFound
+			return
+		}
+		delete(s.connectors, id)
 	})
 	return
 }
@@ -404,6 +447,20 @@ func (s *memStorage) UpdateOfflineSessions(userID string, connID string, updater
 		}
 		if r, err = updater(r); err == nil {
 			s.offlineSessions[id] = r
+		}
+	})
+	return
+}
+
+func (s *memStorage) UpdateConnector(id string, updater func(c storage.Connector) (storage.Connector, error)) (err error) {
+	s.tx(func() {
+		r, ok := s.connectors[id]
+		if !ok {
+			err = storage.ErrNotFound
+			return
+		}
+		if r, err = updater(r); err == nil {
+			s.connectors[id] = r
 		}
 	})
 	return

--- a/storage/sql/migrate.go
+++ b/storage/sql/migrate.go
@@ -176,4 +176,15 @@ var migrations = []migration{
 			);
 		`,
 	},
+	{
+		stmt: `
+			create table connector (
+				id text not null primary key,
+				type text not null,
+				name text not null,
+				resource_version text not null,
+				config bytea
+			);
+		`,
+	},
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -53,6 +53,7 @@ type Storage interface {
 	CreateRefresh(r RefreshToken) error
 	CreatePassword(p Password) error
 	CreateOfflineSessions(s OfflineSessions) error
+	CreateConnector(c Connector) error
 
 	// TODO(ericchiang): return (T, bool, error) so we can indicate not found
 	// requests that way instead of using ErrNotFound.
@@ -63,10 +64,12 @@ type Storage interface {
 	GetRefresh(id string) (RefreshToken, error)
 	GetPassword(email string) (Password, error)
 	GetOfflineSessions(userID string, connID string) (OfflineSessions, error)
+	GetConnector(id string) (Connector, error)
 
 	ListClients() ([]Client, error)
 	ListRefreshTokens() ([]RefreshToken, error)
 	ListPasswords() ([]Password, error)
+	ListConnectors() ([]Connector, error)
 
 	// Delete methods MUST be atomic.
 	DeleteAuthRequest(id string) error
@@ -75,6 +78,7 @@ type Storage interface {
 	DeleteRefresh(id string) error
 	DeletePassword(email string) error
 	DeleteOfflineSessions(userID string, connID string) error
+	DeleteConnector(id string) error
 
 	// Update methods take a function for updating an object then performs that update within
 	// a transaction. "updater" functions may be called multiple times by a single update call.
@@ -96,6 +100,7 @@ type Storage interface {
 	UpdateRefreshToken(id string, updater func(r RefreshToken) (RefreshToken, error)) error
 	UpdatePassword(email string, updater func(p Password) (Password, error)) error
 	UpdateOfflineSessions(userID string, connID string, updater func(s OfflineSessions) (OfflineSessions, error)) error
+	UpdateConnector(id string, updater func(c Connector) (Connector, error)) error
 
 	// GarbageCollect deletes all expired AuthCodes and AuthRequests.
 	GarbageCollect(now time.Time) (GCResult, error)
@@ -288,6 +293,22 @@ type Password struct {
 
 	// Randomly generated user ID. This is NOT the primary ID of the Password object.
 	UserID string `json:"userID"`
+}
+
+// Connector is an object that contains the metadata about connectors used to login to Dex.
+type Connector struct {
+	// ID that will uniquely identify the connector object.
+	ID string
+	// The Type of the connector. E.g. 'oidc' or 'ldap'
+	Type string
+	// The Name of the connector that is used when displaying it to the end user.
+	Name string
+	// ResourceVersion is the static versioning used to keep track of dynamic configuration
+	// changes to the connector object made by the API calls.
+	ResourceVersion string
+	// Config holds all the configuration information specific to the connector type. Since there
+	// no generic struct we can use for this purpose, it is stored as a byte stream.
+	Config []byte
 }
 
 // VerificationKey is a rotated signing key which can still be used to verify


### PR DESCRIPTION
This change adds the connector object to the back-end storage. This object will be used by the connector APIs.

Added unit tests.

Ran the conformance tests on Kubernetes:
PASS
ok  	github.com/coreos/dex/storage/kubernetes	8.533s
