### PR TITLE
Add userinfo_endpoint provider metadata to discovery endpoint 

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -47,7 +47,8 @@ type Config struct {
 	// StaticPasswords cause the server use this list of passwords rather than
 	// querying the storage. Cannot be specified without enabling a passwords
 	// database.
-	StaticPasswords []password `json:"staticPasswords"`
+	StaticPasswords  []password `json:"staticPasswords"`
+	UserInfoEndpoint string     `json:"userInfoEndpoint"`
 }
 
 type password storage.Password

--- a/cmd/dex/config_test.go
+++ b/cmd/dex/config_test.go
@@ -63,6 +63,8 @@ expiry:
 logger:
   level: "debug"
   format: "json"
+
+userInfoEndpoint: http://127.0.0.1:8000/v1/users
 `)
 
 	want := Config{
@@ -128,6 +130,7 @@ logger:
 			Level:  "debug",
 			Format: "json",
 		},
+		UserInfoEndpoint: "http://127.0.0.1:8000/v1/users",
 	}
 
 	var c Config

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -200,6 +200,7 @@ func serve(cmd *cobra.Command, args []string) error {
 		EnablePasswordDB:       c.EnablePasswordDB,
 		Logger:                 logger,
 		Now:                    now,
+		UserInfoEndpoint:       c.UserInfoEndpoint,
 	}
 	if c.Expiry.SigningKeys != "" {
 		signingKeys, err := time.ParseDuration(c.Expiry.SigningKeys)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -91,16 +91,17 @@ func (s *Server) handlePublicKeys(w http.ResponseWriter, r *http.Request) {
 }
 
 type discovery struct {
-	Issuer        string   `json:"issuer"`
-	Auth          string   `json:"authorization_endpoint"`
-	Token         string   `json:"token_endpoint"`
-	Keys          string   `json:"jwks_uri"`
-	ResponseTypes []string `json:"response_types_supported"`
-	Subjects      []string `json:"subject_types_supported"`
-	IDTokenAlgs   []string `json:"id_token_signing_alg_values_supported"`
-	Scopes        []string `json:"scopes_supported"`
-	AuthMethods   []string `json:"token_endpoint_auth_methods_supported"`
-	Claims        []string `json:"claims_supported"`
+	Issuer           string   `json:"issuer"`
+	Auth             string   `json:"authorization_endpoint"`
+	Token            string   `json:"token_endpoint"`
+	Keys             string   `json:"jwks_uri"`
+	ResponseTypes    []string `json:"response_types_supported"`
+	Subjects         []string `json:"subject_types_supported"`
+	IDTokenAlgs      []string `json:"id_token_signing_alg_values_supported"`
+	Scopes           []string `json:"scopes_supported"`
+	AuthMethods      []string `json:"token_endpoint_auth_methods_supported"`
+	Claims           []string `json:"claims_supported"`
+	UserInfoEndpoint string   `json:"userinfo_endpoint"`
 }
 
 func (s *Server) discoveryHandler() (http.HandlerFunc, error) {
@@ -117,6 +118,7 @@ func (s *Server) discoveryHandler() (http.HandlerFunc, error) {
 			"aud", "email", "email_verified", "exp",
 			"iat", "iss", "locale", "name", "sub",
 		},
+		UserInfoEndpoint: s.userInfoEndpoint.String(),
 	}
 
 	for responseType := range s.supportedResponseTypes {

--- a/server/server.go
+++ b/server/server.go
@@ -65,6 +65,8 @@ type Config struct {
 	Web WebConfig
 
 	Logger logrus.FieldLogger
+
+	UserInfoEndpoint string
 }
 
 // WebConfig holds the server's frontend templates and asset configuration.
@@ -122,6 +124,8 @@ type Server struct {
 	idTokensValidFor time.Duration
 
 	logger logrus.FieldLogger
+
+	userInfoEndpoint url.URL
 }
 
 // NewServer constructs a server from the provided config.
@@ -136,6 +140,10 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	issuerURL, err := url.Parse(c.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("server: can't parse issuer URL")
+	}
+	userInfoEndpoint, err := url.Parse(c.UserInfoEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("server: can't parse UserInfoEndpoint URL")
 	}
 	if c.EnablePasswordDB {
 		c.Connectors = append(c.Connectors, Connector{
@@ -193,6 +201,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		now:                    now,
 		templates:              tmpls,
 		logger:                 c.Logger,
+		userInfoEndpoint:       *userInfoEndpoint,
 	}
 
 	for _, conn := range c.Connectors {


### PR DESCRIPTION
This adds userinfo_endpoint provider metadata to discovery endpoint .well-known/openid-configuration.
 and  make it editable in config file.

This is used for some smart OpenID connect authentication to provide user data profile or infomations.

https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata