### PR TITLE
Validate audience with entityIssuer if present, use redirectURI otherwise

### DIFF
--- a/Documentation/saml-connector.md
+++ b/Documentation/saml-connector.md
@@ -40,6 +40,8 @@ connectors:
     # insecureSkipSignatureValidation: true
 
     # Optional: Issuer value for AuthnRequest
+    # Must be contained within the "AudienceRestriction" attribute in all responses
+    # If not set, redirectURI will be used for audience validation
     entityIssuer: https://dex.example.com/callback
 
     # Optional: Issuer value for SAML Response

--- a/connector/saml/saml.go
+++ b/connector/saml/saml.go
@@ -466,6 +466,10 @@ func (p *provider) validateConditions(assertion *assertion) error {
 		}
 	}
 	// Validates audience
+	audienceValue := p.entityIssuer
+	if audienceValue == "" {
+		audienceValue = p.redirectURI
+	}
 	audienceRestriction := conditions.AudienceRestriction
 	if audienceRestriction != nil {
 		audiences := audienceRestriction.Audiences
@@ -473,14 +477,14 @@ func (p *provider) validateConditions(assertion *assertion) error {
 			values := make([]string, len(audiences))
 			issuerInAudiences := false
 			for i, audience := range audiences {
-				if audience.Value == p.redirectURI {
+				if audience.Value == audienceValue {
 					issuerInAudiences = true
 					break
 				}
 				values[i] = audience.Value
 			}
 			if !issuerInAudiences {
-				return fmt.Errorf("required audience %s was not in Response audiences %s", p.redirectURI, values)
+				return fmt.Errorf("required audience %s was not in Response audiences %s", audienceValue, values)
 			}
 		}
 	}


### PR DESCRIPTION
Comparing with the spec, it appears that Audience values refer to EntityIssuer, and not RedirectURI (though in most cases they are the same, but not all).

This sets EntityIssuer to RedirectURI by default if it is not explicitly set, allowing implementations that need it to function correctly.

Spec: http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html

We see that EntityIssuer is `https://sp.example.com/SAML2`, but Destination is `https://sp.example.com/SAML2/SSO/POST`

```xml
<samlp:AuthnRequest
xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
ID="identifier_1"
Version="2.0"
IssueInstant="2004-12-05T09:21:59Z"
AssertionConsumerServiceIndex="1">
<saml:Issuer>https://sp.example.com/SAML2</saml:Issuer>
<samlp:NameIDPolicy
AllowCreate="true"
Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"/>
</samlp:AuthnRequest>
```

```xml
<samlp:Response
xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
ID="identifier_2"
InResponseTo="identifier_1"
Version="2.0"
IssueInstant="2004-12-05T09:22:05Z"
Destination="https://sp.example.com/SAML2/SSO/POST">
<saml:Issuer>https://idp.example.org/SAML2</saml:Issuer>
<samlp:Status>
<samlp:StatusCode
Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
</samlp:Status>
<saml:Assertion
xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
ID="identifier_3"
Version="2.0"
IssueInstant="2004-12-05T09:22:05Z">
<saml:Issuer>https://idp.example.org/SAML2</saml:Issuer>
<!-- a POSTed assertion MUST be signed -->
<ds:Signature
xmlns:ds="http://www.w3.org/2000/09/xmldsig#">...</ds:Signature>
<saml:Subject>
<saml:NameID
Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">
3f7b3dcf-1674-4ecd-92c8-1544f346baf8
</saml:NameID>
<saml:SubjectConfirmation
Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
<saml:SubjectConfirmationData
InResponseTo="identifier_1"
Recipient="https://sp.example.com/SAML2/SSO/POST"
NotOnOrAfter="2004-12-05T09:27:05Z"/>
</saml:SubjectConfirmation>
</saml:Subject>
<saml:Conditions
NotBefore="2004-12-05T09:17:05Z"
NotOnOrAfter="2004-12-05T09:27:05Z">
<saml:AudienceRestriction>
<saml:Audience>https://sp.example.com/SAML2</saml:Audience>
</saml:AudienceRestriction>
</saml:Conditions>
<saml:AuthnStatement
AuthnInstant="2004-12-05T09:22:00Z"
SessionIndex="identifier_3">
<saml:AuthnContext>
<saml:AuthnContextClassRef>
urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
</saml:AuthnContextClassRef>
</saml:AuthnContext>
</saml:AuthnStatement>
</saml:Assertion>
</samlp:Response>
```