### PR TITLE
server/rotation.go: avoid displaying the "keys already rotated" error

### DIFF
--- a/server/rotation.go
+++ b/server/rotation.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -125,8 +124,11 @@ func (k keyRotater) rotate() error {
 	var nextRotation time.Time
 	err = k.Storage.UpdateKeys(func(keys storage.Keys) (storage.Keys, error) {
 		tNow := k.now()
+
+		// if you are running multiple instances of dex, another instance
+		// could have already rotated the keys.
 		if tNow.Before(keys.NextRotation) {
-			return storage.Keys{}, errors.New("keys already rotated")
+			return storage.Keys{}, nil
 		}
 
 		expired := func(key storage.VerificationKey) bool {


### PR DESCRIPTION
Fixes https://github.com/coreos/dex/issues/890.

If the user is running multiple instances of dex, it is possible that one instance can rotate the keys before another gets around to doing it. Since this is an acceptable situation, we can avoid logging this as an error.