### PR TITLE
server: account for dynamically changing connector object in storage.

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -9,13 +9,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/coreos/dex/connector"
-	"github.com/coreos/dex/connector/github"
-	"github.com/coreos/dex/connector/gitlab"
-	"github.com/coreos/dex/connector/ldap"
-	"github.com/coreos/dex/connector/mock"
-	"github.com/coreos/dex/connector/oidc"
-	"github.com/coreos/dex/connector/saml"
 	"github.com/coreos/dex/server"
 	"github.com/coreos/dex/storage"
 	"github.com/coreos/dex/storage/kubernetes"
@@ -25,16 +18,19 @@ import (
 
 // Config is the config format for the main application.
 type Config struct {
-	Issuer     string      `json:"issuer"`
-	Storage    Storage     `json:"storage"`
-	Connectors []Connector `json:"connectors"`
-	Web        Web         `json:"web"`
-	OAuth2     OAuth2      `json:"oauth2"`
-	GRPC       GRPC        `json:"grpc"`
-	Expiry     Expiry      `json:"expiry"`
-	Logger     Logger      `json:"logger"`
+	Issuer  string  `json:"issuer"`
+	Storage Storage `json:"storage"`
+	Web     Web     `json:"web"`
+	OAuth2  OAuth2  `json:"oauth2"`
+	GRPC    GRPC    `json:"grpc"`
+	Expiry  Expiry  `json:"expiry"`
+	Logger  Logger  `json:"logger"`
 
 	Frontend server.WebConfig `json:"frontend"`
+
+	// StaticConnectors are user defined connectors specified in the ConfigMap
+	// Write operations, like updating a connector, will fail.
+	StaticConnectors []Connector `json:"connectors"`
 
 	// StaticClients cause the server to use this list of clients rather than
 	// querying the storage. Write operations, like creating a client, will fail.
@@ -170,24 +166,7 @@ type Connector struct {
 	Name string `json:"name"`
 	ID   string `json:"id"`
 
-	Config ConnectorConfig `json:"config"`
-}
-
-// ConnectorConfig is a configuration that can open a connector.
-type ConnectorConfig interface {
-	Open(logrus.FieldLogger) (connector.Connector, error)
-}
-
-var connectors = map[string]func() ConnectorConfig{
-	"mockCallback": func() ConnectorConfig { return new(mock.CallbackConfig) },
-	"mockPassword": func() ConnectorConfig { return new(mock.PasswordConfig) },
-	"ldap":         func() ConnectorConfig { return new(ldap.Config) },
-	"github":       func() ConnectorConfig { return new(github.Config) },
-	"gitlab":       func() ConnectorConfig { return new(gitlab.Config) },
-	"oidc":         func() ConnectorConfig { return new(oidc.Config) },
-	"saml":         func() ConnectorConfig { return new(saml.Config) },
-	// Keep around for backwards compatibility.
-	"samlExperimental": func() ConnectorConfig { return new(saml.Config) },
+	Config server.ConnectorConfig `json:"config"`
 }
 
 // UnmarshalJSON allows Connector to implement the unmarshaler interface to
@@ -203,7 +182,7 @@ func (c *Connector) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &conn); err != nil {
 		return fmt.Errorf("parse connector: %v", err)
 	}
-	f, ok := connectors[conn.Type]
+	f, ok := server.ConnectorsConfig[conn.Type]
 	if !ok {
 		return fmt.Errorf("unknown connector type %q", conn.Type)
 	}
@@ -222,6 +201,21 @@ func (c *Connector) UnmarshalJSON(b []byte) error {
 		Config: connConfig,
 	}
 	return nil
+}
+
+// ToStorageConnector converts an object to storage connector type.
+func ToStorageConnector(c Connector) (storage.Connector, error) {
+	data, err := json.Marshal(c.Config)
+	if err != nil {
+		return storage.Connector{}, fmt.Errorf("failed to marshal connector config: %v", err)
+	}
+
+	return storage.Connector{
+		ID:     c.ID,
+		Type:   c.Type,
+		Name:   c.Name,
+		Config: data,
+	}, nil
 }
 
 // Expiry holds configuration for the validity period of components.

--- a/cmd/dex/config_test.go
+++ b/cmd/dex/config_test.go
@@ -86,7 +86,7 @@ logger:
 				},
 			},
 		},
-		Connectors: []Connector{
+		StaticConnectors: []Connector{
 			{
 				Type:   "mockCallback",
 				ID:     "mock",

--- a/server/server.go
+++ b/server/server.go
@@ -2,11 +2,13 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"path"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -17,14 +19,23 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/coreos/dex/connector"
+	"github.com/coreos/dex/connector/github"
+	"github.com/coreos/dex/connector/gitlab"
+	"github.com/coreos/dex/connector/ldap"
+	"github.com/coreos/dex/connector/mock"
+	"github.com/coreos/dex/connector/oidc"
+	"github.com/coreos/dex/connector/saml"
 	"github.com/coreos/dex/storage"
 )
 
-// Connector is a connector with metadata.
+// LocalConnector is the local passwordDB connector which is an internal
+// connector maintained by the server.
+const LocalConnector = "local"
+
+// Connector is a connector with resource version metadata.
 type Connector struct {
-	ID          string
-	DisplayName string
-	Connector   connector.Connector
+	ResourceVersion string
+	Connector       connector.Connector
 }
 
 // Config holds the server's configuration options.
@@ -35,9 +46,6 @@ type Config struct {
 
 	// The backing persistence layer.
 	Storage storage.Storage
-
-	// Strategies for federated identity.
-	Connectors []Connector
 
 	// Valid values are "code" to enable the code flow and "token" to enable the implicit
 	// flow. If no response types are supplied this value defaults to "code".
@@ -59,8 +67,6 @@ type Config struct {
 
 	// If specified, the server will use this function for determining time.
 	Now func() time.Time
-
-	EnablePasswordDB bool
 
 	Web WebConfig
 
@@ -103,7 +109,9 @@ func value(val, defaultValue time.Duration) time.Duration {
 type Server struct {
 	issuerURL url.URL
 
-	// Read-only map of connector IDs to connectors.
+	// mutex for the connectors map.
+	mu sync.Mutex
+	// Map of connector IDs to connectors.
 	connectors map[string]Connector
 
 	storage storage.Storage
@@ -137,17 +145,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	if err != nil {
 		return nil, fmt.Errorf("server: can't parse issuer URL")
 	}
-	if c.EnablePasswordDB {
-		c.Connectors = append(c.Connectors, Connector{
-			ID:          "local",
-			DisplayName: "Email",
-			Connector:   newPasswordDB(c.Storage),
-		})
-	}
 
-	if len(c.Connectors) == 0 {
-		return nil, errors.New("server: no connectors specified")
-	}
 	if c.Storage == nil {
 		return nil, errors.New("server: storage cannot be nil")
 	}
@@ -195,8 +193,21 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		logger:                 c.Logger,
 	}
 
-	for _, conn := range c.Connectors {
-		s.connectors[conn.ID] = conn
+	// Retrieves connector objects in backend storage. This list includes the static connectors
+	// defined in the ConfigMap and dynamic connectors retrieved from the storage.
+	storageConnectors, err := c.Storage.ListConnectors()
+	if err != nil {
+		return nil, fmt.Errorf("server: failed to list connector objects from storage: %v", err)
+	}
+
+	if len(storageConnectors) == 0 && len(s.connectors) == 0 {
+		return nil, errors.New("server: no connectors specified")
+	}
+
+	for _, conn := range storageConnectors {
+		if _, err := s.OpenConnector(conn); err != nil {
+			return nil, fmt.Errorf("server: Failed to open connector %s: %v", conn.ID, err)
+		}
 	}
 
 	r := mux.NewRouter()
@@ -361,4 +372,100 @@ func (s *Server) startGarbageCollection(ctx context.Context, frequency time.Dura
 		}
 	}()
 	return
+}
+
+// ConnectorConfig is a configuration that can open a connector.
+type ConnectorConfig interface {
+	Open(logrus.FieldLogger) (connector.Connector, error)
+}
+
+// ConnectorsConfig variable provides an easy way to return a config struct
+// depending on the connector type.
+var ConnectorsConfig = map[string]func() ConnectorConfig{
+	"mockCallback": func() ConnectorConfig { return new(mock.CallbackConfig) },
+	"mockPassword": func() ConnectorConfig { return new(mock.PasswordConfig) },
+	"ldap":         func() ConnectorConfig { return new(ldap.Config) },
+	"github":       func() ConnectorConfig { return new(github.Config) },
+	"gitlab":       func() ConnectorConfig { return new(gitlab.Config) },
+	"oidc":         func() ConnectorConfig { return new(oidc.Config) },
+	"saml":         func() ConnectorConfig { return new(saml.Config) },
+	// Keep around for backwards compatibility.
+	"samlExperimental": func() ConnectorConfig { return new(saml.Config) },
+}
+
+// openConnector will parse the connector config and open the connector.
+func openConnector(logger logrus.FieldLogger, conn storage.Connector) (connector.Connector, error) {
+	var c connector.Connector
+
+	f, ok := ConnectorsConfig[conn.Type]
+	if !ok {
+		return c, fmt.Errorf("unknown connector type %q", conn.Type)
+	}
+
+	connConfig := f()
+	if len(conn.Config) != 0 {
+		data := []byte(string(conn.Config))
+		if err := json.Unmarshal(data, connConfig); err != nil {
+			return c, fmt.Errorf("parse connector config: %v", err)
+		}
+	}
+
+	c, err := connConfig.Open(logger)
+	if err != nil {
+		return c, fmt.Errorf("failed to create connector %s: %v", conn.ID, err)
+	}
+
+	return c, nil
+}
+
+// OpenConnector updates server connector map with specified connector object.
+func (s *Server) OpenConnector(conn storage.Connector) (Connector, error) {
+	var c connector.Connector
+
+	if conn.Type == LocalConnector {
+		c = newPasswordDB(s.storage)
+	} else {
+		var err error
+		c, err = openConnector(s.logger.WithField("connector", conn.Name), conn)
+		if err != nil {
+			return Connector{}, fmt.Errorf("failed to open connector: %v", err)
+		}
+	}
+
+	connector := Connector{
+		ResourceVersion: conn.ResourceVersion,
+		Connector:       c,
+	}
+	s.mu.Lock()
+	s.connectors[conn.ID] = connector
+	s.mu.Unlock()
+
+	return connector, nil
+}
+
+// getConnector retrieves the connector object with the given id from the storage
+// and updates the connector list for server if necessary.
+func (s *Server) getConnector(id string) (Connector, error) {
+	storageConnector, err := s.storage.GetConnector(id)
+	if err != nil {
+		return Connector{}, fmt.Errorf("failed to get connector object from storage: %v", err)
+	}
+
+	var conn Connector
+	var ok bool
+	s.mu.Lock()
+	conn, ok = s.connectors[id]
+	s.mu.Unlock()
+
+	if !ok || storageConnector.ResourceVersion != conn.ResourceVersion {
+		// Connector object does not exist in server connectors map or
+		// has been updated in the storage. Need to get latest.
+		conn, err := s.OpenConnector(storageConnector)
+		if err != nil {
+			return Connector{}, fmt.Errorf("failed to open connector: %v", err)
+		}
+		return conn, nil
+	}
+
+	return conn, nil
 }

--- a/storage/conformance/conformance.go
+++ b/storage/conformance/conformance.go
@@ -628,6 +628,10 @@ func testConnectorCRUD(t *testing.T, s storage.Storage) {
 	c1.Type = "oidc"
 	getAndCompare(id1, c1)
 
+	if _, err := s.ListConnectors(); err != nil {
+		t.Fatalf("failed to list connectors: %v", err)
+	}
+
 	if err := s.DeleteConnector(c1.ID); err != nil {
 		t.Fatalf("failed to delete connector: %v", err)
 	}

--- a/storage/static.go
+++ b/storage/static.go
@@ -150,3 +150,73 @@ func (s staticPasswordsStorage) UpdatePassword(email string, updater func(old Pa
 	}
 	return s.Storage.UpdatePassword(email, updater)
 }
+
+// staticConnectorsStorage represents a storage with read-only set of connectors.
+type staticConnectorsStorage struct {
+	Storage
+
+	// A read-only set of connectors.
+	connectors     []Connector
+	connectorsByID map[string]Connector
+}
+
+// WithStaticConnectors returns a storage with a read-only set of Connectors. Write actions,
+// such as updating existing Connectors, will fail.
+func WithStaticConnectors(s Storage, staticConnectors []Connector) Storage {
+	connectorsByID := make(map[string]Connector, len(staticConnectors))
+	for _, c := range staticConnectors {
+		connectorsByID[c.ID] = c
+	}
+	return staticConnectorsStorage{s, staticConnectors, connectorsByID}
+}
+
+func (s staticConnectorsStorage) isStatic(id string) bool {
+	_, ok := s.connectorsByID[id]
+	return ok
+}
+
+func (s staticConnectorsStorage) GetConnector(id string) (Connector, error) {
+	if connector, ok := s.connectorsByID[id]; ok {
+		return connector, nil
+	}
+	return s.Storage.GetConnector(id)
+}
+
+func (s staticConnectorsStorage) ListConnectors() ([]Connector, error) {
+	connectors, err := s.Storage.ListConnectors()
+	if err != nil {
+		return nil, err
+	}
+
+	n := 0
+	for _, connector := range connectors {
+		// If an entry has the same id as those provided in the static
+		// values, prefer the static value.
+		if !s.isStatic(connector.ID) {
+			connectors[n] = connector
+			n++
+		}
+	}
+	return append(connectors[:n], s.connectors...), nil
+}
+
+func (s staticConnectorsStorage) CreateConnector(c Connector) error {
+	if s.isStatic(c.ID) {
+		return errors.New("static connectors: read-only cannot create connector")
+	}
+	return s.Storage.CreateConnector(c)
+}
+
+func (s staticConnectorsStorage) DeleteConnector(id string) error {
+	if s.isStatic(id) {
+		return errors.New("static connectors: read-only cannot delete connector")
+	}
+	return s.Storage.DeleteConnector(id)
+}
+
+func (s staticConnectorsStorage) UpdateConnector(id string, updater func(old Connector) (Connector, error)) error {
+	if s.isStatic(id) {
+		return errors.New("static connectors: read-only cannot update connector")
+	}
+	return s.Storage.UpdateConnector(id, updater)
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -298,17 +298,17 @@ type Password struct {
 // Connector is an object that contains the metadata about connectors used to login to Dex.
 type Connector struct {
 	// ID that will uniquely identify the connector object.
-	ID string
+	ID string `json:"id"`
 	// The Type of the connector. E.g. 'oidc' or 'ldap'
-	Type string
+	Type string `json:"type"`
 	// The Name of the connector that is used when displaying it to the end user.
-	Name string
+	Name string `json:"name"`
 	// ResourceVersion is the static versioning used to keep track of dynamic configuration
 	// changes to the connector object made by the API calls.
-	ResourceVersion string
+	ResourceVersion string `json:"resourceVersion"`
 	// Config holds all the configuration information specific to the connector type. Since there
 	// no generic struct we can use for this purpose, it is stored as a byte stream.
-	Config []byte
+	Config []byte `json:"email"`
 }
 
 // VerificationKey is a rotated signing key which can still be used to verify


### PR DESCRIPTION
This change enables connector objects to be dynamically modifiable. The connectors defined by the user in the Dex ConfigMap will be deemed as static connectors and will be 'read-only'. 

Dynamic connectors can be created, updated or deleted via gRPC API calls from a dex client (api calls yet to be implemented). This essentially means that every time the dex server refers to a connector object it needs to ensure that it has retrieved the latest version of this connector object from the storage.