### PR TITLE
Expand env vars in staticClients

### DIFF
--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -34,7 +34,7 @@ type Config struct {
 
 	// StaticClients cause the server to use this list of clients rather than
 	// querying the storage. Write operations, like creating a client, will fail.
-	StaticClients []storage.Client `json:"staticClients"`
+	StaticClients []client `json:"staticClients"`
 
 	// If enabled, the server will maintain a list of passwords which can be used
 	// to identify a user.
@@ -44,6 +44,19 @@ type Config struct {
 	// querying the storage. Cannot be specified without enabling a passwords
 	// database.
 	StaticPasswords []password `json:"staticPasswords"`
+}
+
+type client storage.Client
+
+func (c *client) UnmarshalJSON(b []byte) error {
+	data := []byte(os.ExpandEnv(string(b)))
+	// unmarshal into a storage.Client to avoid infinite loop
+	var result storage.Client
+	if err := json.Unmarshal(data, &result); err != nil {
+		return fmt.Errorf("parse staticClients: %v", err)
+	}
+	*c = client(result)
+	return nil
 }
 
 type password storage.Password

--- a/cmd/dex/config_test.go
+++ b/cmd/dex/config_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/coreos/dex/connector/mock"
 	"github.com/coreos/dex/connector/oidc"
-	"github.com/coreos/dex/storage"
 	"github.com/coreos/dex/storage/sql"
 	"github.com/ghodss/yaml"
 	"github.com/kylelemons/godebug/pretty"
@@ -76,7 +75,7 @@ logger:
 		Web: Web{
 			HTTP: "127.0.0.1:5556",
 		},
-		StaticClients: []storage.Client{
+		StaticClients: []client{
 			{
 				ID:     "example-app",
 				Secret: "ZXhhbXBsZS1hcHAtc2VjcmV0",

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -134,10 +134,12 @@ func serve(cmd *cobra.Command, args []string) error {
 	logger.Infof("config storage: %s", c.Storage.Type)
 
 	if len(c.StaticClients) > 0 {
-		for _, client := range c.StaticClients {
+		staticClients := make([]storage.Client, len(c.StaticClients))
+		for i, client := range c.StaticClients {
+			staticClients[i] = storage.Client(client)
 			logger.Infof("config static client: %s", client.ID)
 		}
-		s = storage.WithStaticClients(s, c.StaticClients)
+		s = storage.WithStaticClients(s, staticClients)
 	}
 	if len(c.StaticPasswords) > 0 {
 		passwords := make([]storage.Password, len(c.StaticPasswords))


### PR DESCRIPTION
This is a PR to address https://github.com/coreos/dex/issues/889.

I ran the tests both as currently written, and manually put an env var into the config test. If you have suggestions for how to add the env var explansion testing into that file permanently, I'm happy to add them (not sure how to inject env vars into the test env using Travis).

Also, my original version of this PR accidentally called `WithStaticClients` with an empty client list, but all the tests still passed. I've since fixed that line, but just wanted to call out that functionality doesn't seem to be tested.