### PR TITLE
Documentation/ldap-connector.md: Warn about LDAP connector's bindPW restriction.

### DIFF
--- a/Documentation/ldap-connector.md
+++ b/Documentation/ldap-connector.md
@@ -61,6 +61,8 @@ connectors:
     # The DN and password for an application service account. The connector uses
     # these credentials to search for users and groups. Not required if the LDAP
     # server provides access for anonymous auth.
+    # Please note that if the bind password contains a `$`, it has to be saved in an
+    # environment variable which should be given as the value to `bindPW`.
     bindDN: uid=seviceaccount,cn=users,dc=example,dc=com
     bindPW: password
 


### PR DESCRIPTION
Users will be unable to specify a bindPW with `$` in it directly in the config file. We use os.ExpandEnv to expand the config file and this will look at the '$' and try to apply an environment variable to replace it with and accoridng to the source code https://golang.org/src/os/env.go there is no way to escape it. 

If users want to specify a password with `$` they should save it in an env variable.

Fixes #930 