### PR TITLE
Documentation/github-connector: warn user that GitHub email id should be public.

### DIFF
--- a/Documentation/github-connector.md
+++ b/Documentation/github-connector.md
@@ -6,6 +6,11 @@ One of the login options for dex uses the GitHub OAuth2 flow to identify the end
 
 When a client redeems a refresh token through dex, dex will re-query GitHub to update user information in the ID Token. To do this, __dex stores a readonly GitHub access token in its backing datastore.__ Users that reject dex's access through GitHub will also revoke all dex clients which authenticated them through GitHub.
 
+## Caveats
+
+* Please note that in order for a user to be authenticated via GitHub, the user needs to mark their email id as public on GitHub. This will enable the API to return the user's email to Dex.
+* Currently, authentication via GitHub allows users outside of the `Org` specified in the connector to login. This is being tracked by [issue #920][issue-920].
+
 ## Configuration
 
 Register a new application with [GitHub][github-oauth2] ensuring the callback URL is `(dex issuer)/callback`. For example if dex is listening at the non-root path `https://auth.example.com/dex` the callback would be `https://auth.example.com/dex/callback`.
@@ -65,3 +70,4 @@ connectors:
 ```
 
 [github-oauth2]: https://github.com/settings/applications/new
+[issue-920]: https://github.com/coreos/dex/issues/920


### PR DESCRIPTION
Looks like a lot of users are trying the GitHub connector with private email ids.