### PR TITLE
Google hosted domain support

### DIFF
--- a/Documentation/oidc-connector.md
+++ b/Documentation/oidc-connector.md
@@ -42,6 +42,13 @@ connectors:
     # following field.
     #
     # basicAuthUnsupported: true
+    
+    # Google supports whitelisting allowed domains when using G Suite
+    # (Google Apps). The following field can be set to a list of domains
+    # that can log in:
+    #
+    # hostedDomains:
+    #  - example.com
 ```
 
 [oidc-doc]: openid-connect.md

--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -1,6 +1,13 @@
 package oidc
 
-import "testing"
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/coreos/dex/connector"
+	"net/url"
+	"os"
+	"reflect"
+	"testing"
+)
 
 func TestKnownBrokenAuthHeaderProvider(t *testing.T) {
 	tests := []struct {
@@ -21,3 +28,95 @@ func TestKnownBrokenAuthHeaderProvider(t *testing.T) {
 		}
 	}
 }
+
+func TestOidcConnector_LoginURL(t *testing.T) {
+	logger := &logrus.Logger{
+		Out:       os.Stderr,
+		Formatter: &logrus.TextFormatter{DisableColors: true},
+		Level:     logrus.DebugLevel,
+	}
+
+	tests := []struct {
+		scopes        connector.Scopes
+		hostedDomains []string
+
+		wantScopes  string
+		wantHdParam string
+	}{
+		{
+			connector.Scopes{}, []string{"example.com"},
+			"openid profile email", "example.com",
+		},
+		{
+			connector.Scopes{}, []string{"mydomain.org", "example.com"},
+			"openid profile email", "*",
+		},
+		{
+			connector.Scopes{}, []string{},
+			"openid profile email", "",
+		},
+		{
+			connector.Scopes{OfflineAccess: true}, []string{},
+			"openid profile email", "",
+		},
+	}
+
+	callback := "https://dex.example.com/callback"
+	state := "secret"
+
+	for _, test := range tests {
+		config := &Config{
+			Issuer:        "https://accounts.google.com",
+			ClientID:      "client-id",
+			ClientSecret:  "client-secret",
+			RedirectURI:   "https://dex.example.com/callback",
+			HostedDomains: test.hostedDomains,
+		}
+
+		conn, err := config.Open(logger)
+		if err != nil {
+			t.Errorf("failed to open connector: %v", err)
+			continue
+		}
+
+		loginURL, err := conn.(connector.CallbackConnector).LoginURL(test.scopes, callback, state)
+		if err != nil {
+			t.Errorf("failed to get login URL: %v", err)
+			continue
+		}
+
+		actual, err := url.Parse(loginURL)
+		if err != nil {
+			t.Errorf("failed to parse login URL: %v", err)
+			continue
+		}
+
+		wanted, _ := url.Parse("https://accounts.google.com/o/oauth2/v2/auth")
+		wantedQuery := &url.Values{}
+		wantedQuery.Set("client_id", config.ClientID)
+		wantedQuery.Set("redirect_uri", config.RedirectURI)
+		wantedQuery.Set("response_type", "code")
+		wantedQuery.Set("state", "secret")
+		wantedQuery.Set("scope", test.wantScopes)
+		if test.wantHdParam != "" {
+			wantedQuery.Set("hd", test.wantHdParam)
+		}
+		wanted.RawQuery = wantedQuery.Encode()
+
+		if !reflect.DeepEqual(actual, wanted) {
+			t.Errorf("Wanted %v, got %v", wanted, actual)
+		}
+	}
+}
+
+//func TestOidcConnector_HandleCallback(t *testing.T) {
+//	logger := &logrus.Logger{
+//		Out:       os.Stderr,
+//		Formatter: &logrus.TextFormatter{DisableColors: true},
+//		Level:     logrus.DebugLevel,
+//	}
+//
+//	tests := []struct {
+//
+//	}
+//}

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -61,6 +61,7 @@ connectors:
 #     clientID: $GOOGLE_CLIENT_ID
 #     clientSecret: $GOOGLE_CLIENT_SECRET
 #     redirectURI: http://127.0.0.1:5556/dex/callback
+#     hostedDomain: $GOOGLE_HOSTED_DOMAIN
 
 # Let dex keep a list of passwords which can be used to login to dex.
 enablePasswordDB: true


### PR DESCRIPTION
See #959 - Google's OIDC implementation supports limiting access to a certain Google Apps / G Suite domain. This lets dex users ensure that only people in their organization can log in, and not just anyone with a Google account.