### PR TITLE
bugfix: avoid generating an invalid ID attribute in SAML's AuthenRequest element

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -30,8 +30,8 @@ func NewID() string {
 	if _, err := io.ReadFull(rand.Reader, buff); err != nil {
 		panic(err)
 	}
-	// Trim padding
-	return strings.TrimRight(encoding.EncodeToString(buff), "=")
+	// Avoid the identifier to begin with number and trim padding
+	return string(buff[0]%26+'a') + strings.TrimRight(encoding.EncodeToString(buff[1:]), "=")
 }
 
 // GCResult returns the number of objects deleted by garbage collection.


### PR DESCRIPTION
Our team is going to use Azure AD as an IdP with SAML 2.0 connector. However, when the connector sends an AuthnRequest to Azure AD's endpoint, Azure AD often responds with an error message such as `The request is not a valid Saml2 protocol message`.

After a brief investigation, I found that the connector often generates an AuthnRequest whose ID attribute starts with a digit though such an ID attribute is forbidden by the XML specification. The ID attribute is originally generated by `storage.NewID()` and this PR will change the behavior of the function to avoid generating an ID which starts with a digit.

Refs: https://www.w3.org/TR/REC-xml/#sec-attribute-types
