### PR TITLE
.travis.yml: bump golang version to 1.8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 
 go:
   - 1.7.5
-  - 1.8
+  - 1.8.3
 
 services:
   - postgresql


### PR DESCRIPTION
thanks for catching this, @ericchiang.