### PR TITLE
connector/gitlab: fix default scope and API URL structure

### DIFF
--- a/Documentation/gitlab-connector.md
+++ b/Documentation/gitlab-connector.md
@@ -20,10 +20,42 @@ connectors:
     # Required field for connector name.
     name: GitLab
     config:
-      # optional, default = https://www.gitlab.com 
-      baseURL: https://www.gitlab.com
       # Credentials can be string literals or pulled from the environment.  
-      clientID: $GITLAB_APPLICATION_ID 
+      clientID: $GITLAB_APPLICATION_ID
       clientSecret: $GITLAB_CLIENT_SECRET
       redirectURI: http://127.0.0.1:5556/dex/callback
+      # Optional group, communicate through the "groups" scope.
+      #
+      # NOTE: This is an EXPERIMENTAL config option and will likely change.
+      group: my-group
+```
+
+Users can use their GitLab Enterprise account to login to dex. The following configuration can be used to enable a GitLab Enterprise connector on dex:
+
+```yaml
+connectors:
+- type: gitlab
+  # Required field for connector id.
+  id: gitlab
+  # Required field for connector name.
+  name: GitLab
+  config:
+    # Required fields. Dex must be pre-registered with GitLab Enterprise
+    # to get the following values.
+    # Credentials can be string literals or pulled from the environment.
+    clientID: $GITLAB_CLIENT_ID
+    clientSecret: $GITLAB_CLIENT_SECRET
+    redirectURI: http://127.0.0.1:5556/dex/callback
+    # Optional group, communicate through the "groups" scope.
+    #
+    # NOTE: This is an EXPERIMENTAL config option and will likely change.
+    group: my-group
+
+    # Required ONLY for GitLab Enterprise.
+    # This is the Hostname of the GitLab Enterprise account listed on the
+    # management console. Ensure this domain is routable on your network.
+    hostName: git.example.com
+    # ONLY for GitLab Enterprise. Optional field.
+    # Used to support self-signed or untrusted CA root certificates.
+    rootCA: /etc/dex/ca.crt
 ```


### PR DESCRIPTION
connector/gitlab: removed hard-coded default scope and fixed API URL structure

Documentation: updated connector field examples, added enterprise instructions.

Set the default scope to 'read_user' instead of providing full API access via the 'api' scope. Only grant full API access if a user sets the 'Groups' scope. Also refactored API URL structure in both gitlabConnector and query functions.

Made gitlab connector config more like githubs': enterprise support, group support

Tests: manually tested with `read_user` and `api` scopes by changing both example-app scopes, and GitLab OAuth app authorization levels in the GitLab OAuth app console.

Fixes #1009 