### PR TITLE
[WIP] .travis.yml: add kubernetes storage tests to CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 bin
 dist
 _output
+
+# Minikube storage tests
+**.minikube

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,21 @@ services:
   - postgresql
 
 env:
-  - DEX_POSTGRES_DATABASE=postgres DEX_POSTGRES_USER=postgres DEX_POSTGRES_HOST="localhost" DEX_LDAP_TESTS=1 DEBIAN_FRONTEND=noninteractive
-
+  - DEBIAN_FRONTEND=noninteractive DEX_POSTGRES_DATABASE=postgres DEX_POSTGRES_USER=postgres DEX_POSTGRES_HOST="localhost" DEX_LDAP_TESTS=1 DEX_KUBECONFIG="$(pwd)/storage/kubernetes/testdata/kubeconfig.yaml"
 
 install:
   - go get -u github.com/golang/lint/golint
   - sudo -E apt-get install -y --force-yes slapd time ldap-utils
   - sudo /etc/init.d/slapd stop
 
+before_script:
+  - ./scripts/start-minikube
 
 script:
   - make testall
+
+after_script:
+  - ./scripts/stop-minikube
 
 notifications:
   email: false

--- a/scripts/start-minikube
+++ b/scripts/start-minikube
@@ -1,0 +1,33 @@
+#!/bin/bash -x
+# Script adapted from https://github.com/kubernetes/minikube#linux-ci-installation-which-supports-running-in-a-vm-example-w-kubectl-installation
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR="$(mktemp -d -p "$DIR")"
+
+if command -v minikube; then
+  ln -sf "$(command -v minikube)" "$BIN_DIR"/minikube
+else
+  curl -Lo "$BIN_DIR"/minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+fi
+
+if command -v kubectl; then
+  ln -sf "$(command -v kubectl)" "$BIN_DIR"/kubectl
+else
+  stable_release="$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"
+  curl -Lo "$BIN_DIR"/kubectl https://storage.googleapis.com/kubernetes-release/release/"$stable_release"/bin/linux/amd64/kubectl
+fi
+chmod -R +x "$BIN_DIR"
+
+export PATH="${BIN_DIR}:${PATH}"
+export MINIKUBE_WANTUPDATENOTIFICATION=false
+export MINIKUBE_WANTREPORTERRORPROMPT=false
+export MINIKUBE_HOME="$DIR"
+export CHANGE_MINIKUBE_NONE_USER=true
+export KUBECONFIG="$DEX_KUBECONFIG"
+sudo -E "$BIN_DIR"/minikube start --vm-driver=none
+
+# this for loop waits until kubectl can access the api server that minikube has created
+for i in {1..150}; do # timeout for 5 minutes
+  if "$BIN_DIR"/kubectl get pods &> /dev/null; then break; fi
+  sleep 2
+done

--- a/scripts/stop-minikube
+++ b/scripts/stop-minikube
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR=$(find "$DIR" -name minikube -not -type d -exec dirname {} \;)
+
+trap "rm -rf $BIN_DIR; exit" EXIT
+
+"$BIN_DIR"/minikube delete

--- a/storage/kubernetes/testdata/kubeconfig.yaml
+++ b/storage/kubernetes/testdata/kubeconfig.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: test-cluster-name
+  cluster:
+    server: 127.0.0.1
+users:
+- name: kubelet
+  user:
+prefernces: {}
+contexts:
+- name: test-cluster-context
+  context:
+    cluster: test-cluster-name
+    user: kubelet
+current-context: test-cluster-context


### PR DESCRIPTION
.travis.yml: add kubernetes storage tests to CI
scripts: minikube start/stop scripts
storage: test kubeconfig

Kubernetes storage is currently not being tested in CI and should be.

Fixes #833 