### PR TITLE
added possibility to choose connector in request from client

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -167,6 +167,11 @@ func (s *Server) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if authReq.ConnectorID != "" {
+		http.Redirect(w, r, s.absPath("/auth", authReq.ConnectorID)+"?req="+authReq.ID, http.StatusFound)
+		return
+	}
+
 	connectors, e := s.storage.ListConnectors()
 	if e != nil {
 		s.logger.Errorf("Failed to get list of connectors: %v", err)

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -476,6 +476,7 @@ func (s *Server) parseAuthorizationRequest(r *http.Request) (req storage.AuthReq
 		Scopes:              scopes,
 		RedirectURI:         redirectURI,
 		ResponseTypes:       responseTypes,
+		ConnectorID:         connector,
 	}, nil
 }
 


### PR DESCRIPTION
Perhaps this will be useful to someone else.
I use this little hack for different groups filter (LDAP) for different client applications (dex used as OIDC for internal SSO)