### PR TITLE
connector/gitlab: correct scope strings, better default

### DIFF
--- a/connector/gitlab/gitlab.go
+++ b/connector/gitlab/gitlab.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	scopeEmail = "user:email"
-	scopeOrgs  = "read:org"
+	// https://docs.gitlab.com/ee/integration/oauth_provider.html#authorized-applications
+	scopeUser = "read_user"
+	scopeAPI  = "api"
 )
 
 // Config holds configuration options for gilab logins.
@@ -78,7 +79,11 @@ type gitlabConnector struct {
 }
 
 func (c *gitlabConnector) oauth2Config(scopes connector.Scopes) *oauth2.Config {
-	gitlabScopes := []string{"api"}
+	gitlabScopes := []string{scopeUser}
+	if scopes.Groups {
+		gitlabScopes = []string{scopeAPI}
+	}
+
 	gitlabEndpoint := oauth2.Endpoint{AuthURL: c.baseURL + "/oauth/authorize", TokenURL: c.baseURL + "/oauth/token"}
 	return &oauth2.Config{
 		ClientID:     c.clientID,
@@ -198,7 +203,7 @@ func (c *gitlabConnector) Refresh(ctx context.Context, s connector.Scopes, ident
 // a bearer token as part of the request.
 func (c *gitlabConnector) user(ctx context.Context, client *http.Client) (gitlabUser, error) {
 	var u gitlabUser
-	req, err := http.NewRequest("GET", c.baseURL+"/api/v3/user", nil)
+	req, err := http.NewRequest("GET", c.baseURL+"/api/v4/user", nil)
 	if err != nil {
 		return u, fmt.Errorf("gitlab: new req: %v", err)
 	}
@@ -229,7 +234,7 @@ func (c *gitlabConnector) user(ctx context.Context, client *http.Client) (gitlab
 // which inserts a bearer token as part of the request.
 func (c *gitlabConnector) groups(ctx context.Context, client *http.Client) ([]string, error) {
 
-	apiURL := c.baseURL + "/api/v3/groups"
+	apiURL := c.baseURL + "/api/v4/groups"
 
 	reNext := regexp.MustCompile("<(.*)>; rel=\"next\"")
 	reLast := regexp.MustCompile("<(.*)>; rel=\"last\"")


### PR DESCRIPTION
connector/gitlab: correct scope strings, better default scope, and update-able scopes

Current scope strings were taken from GitHub API, and are incorrect. Scopes cannot be updated either. This PR fixes both issues. API version upgraded to support scopes, and is the latest API version.

Fixes #1009 