### PR TITLE
Documentation: fix redirect caveat description

### DIFF
--- a/Documentation/github-connector.md
+++ b/Documentation/github-connector.md
@@ -8,8 +8,7 @@ When a client redeems a refresh token through dex, dex will re-query GitHub to u
 
 ## Caveats
 
-* The GitHub API calls dex uses requires a user to have their organization membership visibility set to public. This can be done on the ["request access from org" page][github-request-org-access] which GitHub will skip if the client app is an existing authorized application. The current workaround is as follows: the user should log into their GitHub account, go to Settings -> Authorized OAuth Apps, click 'Revoke' to revoke the application's grant, and restart the dex login process. This will force the "request access from org" page to be shown, allowing the user to request that the organization owner make their membership public.
-    * Note: GitHub [organizations][github-orgs] are different from GitHub [teams][github-teams]
+* A user must explicitly [request][github-request-org-access] an [organization][github-orgs] give dex [resource access][github-approve-org-access]. Dex will not have the correct permissions to determine if the user is in that organization otherwise, and the user will not be able to log in. This request mechanism is a feature of the GitHub API.
 
 ## Configuration
 
@@ -50,7 +49,7 @@ connectors:
     - name: my-organization-with-teams
       # A white list of teams. Only include group claims for these teams.
       teams:
-      - read-team
+      - red-team
       - blue-team
 ```
 
@@ -93,7 +92,7 @@ connectors:
     - name: my-organization-with-teams
       # A white list of teams. Only include group claims for these teams.
       teams:
-      - read-team
+      - red-team
       - blue-team
     # Required ONLY for GitHub Enterprise.
     # This is the Hostname of the GitHub Enterprise account listed on the
@@ -106,5 +105,5 @@ connectors:
 
 [github-oauth2]: https://github.com/settings/applications/new
 [github-orgs]: https://developer.github.com/v3/orgs/
-[github-teams]: https://developer.github.com/v3/orgs/teams/
 [github-request-org-access]: https://help.github.com/articles/requesting-organization-approval-for-oauth-apps/
+[github-approve-org-access]: https://help.github.com/articles/approving-oauth-apps-for-your-organization/


### PR DESCRIPTION
Part of the caveat currently described by GitHub connector documentation is no longer an issue, but the part relating to re-authorization of an application after being added to an organization is still valid.