### PR TITLE
connector/github: fix username used when making API requests

### DIFF
--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -247,16 +247,16 @@ func (c *githubConnector) HandleCallback(s connector.Scopes, r *http.Request) (i
 	if s.Groups {
 		var groups []string
 		if len(c.orgs) > 0 {
-			if groups, err = c.listGroups(ctx, client, username); err != nil {
+			if groups, err = c.listGroups(ctx, client, user.Login); err != nil {
 				return identity, err
 			}
 		} else if c.org != "" {
-			inOrg, err := c.userInOrg(ctx, client, username, c.org)
+			inOrg, err := c.userInOrg(ctx, client, user.Login, c.org)
 			if err != nil {
 				return identity, err
 			}
 			if !inOrg {
-				return identity, fmt.Errorf("github: user %q not a member of org %q", username, c.org)
+				return identity, fmt.Errorf("github: user %q not a member of org %q", user.Login, c.org)
 			}
 			if groups, err = c.teams(ctx, client, c.org); err != nil {
 				return identity, fmt.Errorf("github: get teams: %v", err)
@@ -303,16 +303,16 @@ func (c *githubConnector) Refresh(ctx context.Context, s connector.Scopes, ident
 	if s.Groups {
 		var groups []string
 		if len(c.orgs) > 0 {
-			if groups, err = c.listGroups(ctx, client, username); err != nil {
+			if groups, err = c.listGroups(ctx, client, user.Login); err != nil {
 				return identity, err
 			}
 		} else if c.org != "" {
-			inOrg, err := c.userInOrg(ctx, client, username, c.org)
+			inOrg, err := c.userInOrg(ctx, client, user.Login, c.org)
 			if err != nil {
 				return identity, err
 			}
 			if !inOrg {
-				return identity, fmt.Errorf("github: user %q not a member of org %q", username, c.org)
+				return identity, fmt.Errorf("github: user %q not a member of org %q", user.Login, c.org)
 			}
 			if groups, err = c.teams(ctx, client, c.org); err != nil {
 				return identity, fmt.Errorf("github: get teams: %v", err)


### PR DESCRIPTION
Removed logic that used a GitHub users' display name over their login name. Login name will work in API requests while display name will not.

Fixes a bug where users with both a display name and login name would not see org membership correctly.

Tests: ran through all cases in #1019 manually

Fixes #1032 