### PR TITLE
When connecting to GitHub Enterprise, force email verified field to true

### DIFF
--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -503,6 +503,11 @@ func (c *githubConnector) userEmail(ctx context.Context, client *http.Client) (s
 		}
 
 		for _, email := range emails {
+			// if GitHub Enterprise, set email.Verified to true
+			if c.hostName != "" {
+				email.Verified = true
+			}
+			
 			if email.Verified && email.Primary {
 				return email.Email, nil
 			}

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -503,7 +503,16 @@ func (c *githubConnector) userEmail(ctx context.Context, client *http.Client) (s
 		}
 
 		for _, email := range emails {
-			// if GitHub Enterprise, set email.Verified to true
+			/*
+				if GitHub Enterprise, set email.Verified to true
+				This change being made because GitHub Enterprise does not
+				support email verification. CircleCI indicated that GitHub
+				advised them not to check for verified emails
+				(https://circleci.com/enterprise/changelog/#1-47-1).
+				In addition, GitHub Enterprise support replied to a support
+				ticket with "There is no way to verify an email address in 
+				GitHub Enterprise."			
+			*/
 			if c.hostName != "" {
 				email.Verified = true
 			}


### PR DESCRIPTION
This change being made to account for GitHub Enterprise not supporting verified emails. If connecting to GitHub Enterprise (as indicated by hostName field being populated), the email.Verified field is set to true regardless of what comes back from the GitHub API.