### PR TITLE
server: set sane bcrypt cost upper bound

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -21,8 +21,16 @@ import (
 // to determine if the server supports specific features.
 const apiVersion = 2
 
-// recCost is the recommended bcrypt cost, which balances hash strength and time
-const recCost = 12
+const (
+	// recCost is the recommended bcrypt cost, which balances hash strength and
+	// efficiency.
+	recCost = 12
+
+	// upBoundCost is a sane upper bound on bcrypt cost determined by benchmarking:
+	// high enough to ensure secure encryption, low enough to not put unnecessary
+	// load on a dex server.
+	upBoundCost = 16
+)
 
 // NewAPI returns a server which implements the gRPC API interface.
 func NewAPI(s storage.Storage, logger logrus.FieldLogger) api.DexServer {
@@ -83,16 +91,20 @@ func (d dexAPI) DeleteClient(ctx context.Context, req *api.DeleteClientReq) (*ap
 	return &api.DeleteClientResp{}, nil
 }
 
-// checkCost returns an error if the hash provided does not meet minimum cost requirement, and the actual bcrypt cost
-func checkCost(hash []byte) (int, error) {
+// checkCost returns an error if the hash provided does not meet lower or upper
+// bound cost requirements.
+func checkCost(hash []byte) error {
 	actual, err := bcrypt.Cost(hash)
 	if err != nil {
-		return 0, fmt.Errorf("parsing bcrypt hash: %v", err)
+		return fmt.Errorf("parsing bcrypt hash: %v", err)
 	}
 	if actual < bcrypt.DefaultCost {
-		return actual, fmt.Errorf("given hash cost = %d, does not meet minimum cost requirement = %d", actual, bcrypt.DefaultCost)
+		return fmt.Errorf("given hash cost = %d does not meet minimum cost requirement = %d", actual, bcrypt.DefaultCost)
 	}
-	return actual, nil
+	if actual > upBoundCost {
+		return fmt.Errorf("given hash cost = %d is above upper bound cost = %d, recommended cost = %d", actual, upBoundCost, recCost)
+	}
+	return nil
 }
 
 func (d dexAPI) CreatePassword(ctx context.Context, req *api.CreatePasswordReq) (*api.CreatePasswordResp, error) {
@@ -103,12 +115,8 @@ func (d dexAPI) CreatePassword(ctx context.Context, req *api.CreatePasswordReq) 
 		return nil, errors.New("no user ID supplied")
 	}
 	if req.Password.Hash != nil {
-		cost, err := checkCost(req.Password.Hash)
-		if err != nil {
+		if err := checkCost(req.Password.Hash); err != nil {
 			return nil, err
-		}
-		if cost > recCost {
-			d.logger.Warnln("bcrypt cost = %d, password encryption might timeout. Recommended bcrypt cost is 12", cost)
 		}
 	} else {
 		return nil, errors.New("no hash of password supplied")
@@ -140,12 +148,8 @@ func (d dexAPI) UpdatePassword(ctx context.Context, req *api.UpdatePasswordReq) 
 	}
 
 	if req.NewHash != nil {
-		cost, err := checkCost(req.NewHash)
-		if err != nil {
+		if err := checkCost(req.NewHash); err != nil {
 			return nil, err
-		}
-		if cost > recCost {
-			d.logger.Warnln("bcrypt cost = %d, password encryption might timeout. Recommended bcrypt cost is 12", cost)
 		}
 	}
 

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -132,16 +132,15 @@ func TestCheckCost(t *testing.T) {
 	defer client.Close()
 
 	tests := []struct {
-		name         string
-		inputHash    []byte
-		expectedCost int
-		wantErr      bool
+		name      string
+		inputHash []byte
+
+		wantErr bool
 	}{
 		{
 			name: "valid cost",
-			// bcrypt hash of the value "test1" with cost 12
-			inputHash:    []byte("$2a$12$M2Ot95Qty1MuQdubh1acWOiYadJDzeVg3ve4n5b.dgcgPdjCseKx2"),
-			expectedCost: recCost,
+			// bcrypt hash of the value "test1" with cost 12 (default)
+			inputHash: []byte("$2a$12$M2Ot95Qty1MuQdubh1acWOiYadJDzeVg3ve4n5b.dgcgPdjCseKx2"),
 		},
 		{
 			name:      "invalid hash",
@@ -156,15 +155,14 @@ func TestCheckCost(t *testing.T) {
 		},
 		{
 			name: "cost above recommendation",
-			// bcrypt hash of the value "test1" with cost 20
-			inputHash:    []byte("$2a$20$yODn5quqK9MZdePqYLs6Y.Jr4cOO1P0aXsKz0eTa2rxOmu8e7ETpi"),
-			expectedCost: 20,
+			// bcrypt hash of the value "test1" with cost 17
+			inputHash: []byte("$2a$17$tWuZkTxtSmRyWZAGWVHQE.7npdl.TgP8adjzLJD.SyjpFznKBftPe"),
+			wantErr:   true,
 		},
 	}
 
 	for _, tc := range tests {
-		cost, err := checkCost(tc.inputHash)
-		if err != nil {
+		if err := checkCost(tc.inputHash); err != nil {
 			if !tc.wantErr {
 				t.Errorf("%s: %s", tc.name, err)
 			}
@@ -174,10 +172,6 @@ func TestCheckCost(t *testing.T) {
 		if tc.wantErr {
 			t.Errorf("%s: expected err", tc.name)
 			continue
-		}
-
-		if cost != tc.expectedCost {
-			t.Errorf("%s: exepcted cost = %d but got cost = %d", tc.name, tc.expectedCost, cost)
 		}
 	}
 }


### PR DESCRIPTION
api.go: `checkCost` only returns an error if hash cost is too high or low (or if `Cost` fails)
server.go: remove timeout logic and reverte back to a hash comparison, with an addition cost check
server_test.go: `MinCost` will cause `Login` to error now, so use `DefaultCost` instead.

Instead of timing out after 10 seconds of hashing, dex should not permit a bcrypt hash cost > 16. The below benchmarks show that cost > 16 exponentially grows to times that a user would notice when logging in, considering that dex will likely be running on a server (much beefier than my machine).

Tests for login timeouts have been removed.

Applies to #1030. Middleware for generically timing out requests will be implemented soon.

Benchmarks (Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz):

Cost | Time (sec)
:---: | :---:
10 | 0.073507
11 | 0.151875
12 | 0.301854
13 | 0.596907
14 | 1.151219
15 | 2.365981
**16** | **4.941790**
17 | 9.467757