### PR TITLE
Deflate SAMLRequest (Issue #1042)

### DIFF
--- a/Documentation/saml-connector.md
+++ b/Documentation/saml-connector.md
@@ -53,6 +53,13 @@ connectors:
     #
     # insecureSkipSignatureValidation: true
 
+    # Optional: Compress SAMLRequest
+    #
+    # Some identity providers require SAMLRequest to be deflated
+    # set to true to deflate the request
+    #
+    # compress: true
+
     # Optional: Manually specify dex's Issuer value.
     #
     # When provided dex will include this as the Issuer value during AuthnRequest.


### PR DESCRIPTION
Some identity provider requires SAMLRequest to be
deflated. Add the "compress" option in config to
deflate the request.