### PR TITLE
Resp redirect binding

### DIFF
--- a/Documentation/saml-connector.md
+++ b/Documentation/saml-connector.md
@@ -89,12 +89,16 @@ connectors:
 
     # Optional: Specify binding to use, default is HTTP-POST
     #
+    # requestBinding specifies how AuthnRequest is sent to identity provider
+    # responseBinding specifies how identity provider calls back to dex
+    #
     # Some identity provider may require specific binding
     # supported values:
     #   - post: use HTTP-POST binding (default)
     #   - redirect: use HTTP redirect binding
     #
-    # binding: post
+    # requestBinding: post
+    # responseBinding: post
 ```
 
 A minimal working configuration might look like:

--- a/Documentation/saml-connector.md
+++ b/Documentation/saml-connector.md
@@ -86,6 +86,15 @@ connectors:
     #     urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
     #
     nameIDPolicyFormat: persistent
+
+    # Optional: Specify binding to use, default is HTTP-POST
+    #
+    # Some identity provider may require specific binding
+    # supported values:
+    #   - post: use HTTP-POST binding (default)
+    #   - redirect: use HTTP redirect binding
+    #
+    # binding: post
 ```
 
 A minimal working configuration might look like:

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -84,13 +84,13 @@ type SAMLConnector interface {
 	// SAML request.
 	AuthnRequest(s Scopes, requestID string) (binding, ssoURL, samlRequest string, err error)
 
-	// HandlePOST decodes, verifies, and maps attributes from the SAML response.
+	// HandleResponse decodes, verifies, and maps attributes from the SAML response.
 	// It passes the expected value of the "InResponseTo" response field, which
 	// the connector must ensure matches the response value.
 	//
 	// See: https://www.oasis-open.org/committees/download.php/35711/sstc-saml-core-errata-2.0-wd-06-diff.pdf
 	// "3.2.2 Complex Type StatusResponseType"
-	HandlePOST(s Scopes, samlResponse, inResponseTo string) (identity Identity, err error)
+	HandleResponse(s Scopes, samlResponse, inResponseTo string) (identity Identity, err error)
 }
 
 // RefreshConnector is a connector that can update the client claims.

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -65,18 +65,24 @@ type CallbackConnector interface {
 	HandleCallback(s Scopes, r *http.Request) (identity Identity, err error)
 }
 
+// SAMLConnector bindings
+const (
+	SAMLBindingPOST     = "post"
+	SAMLBindingRedirect = "redirect"
+)
+
 // SAMLConnector represents SAML connectors which implement the HTTP POST binding.
 //  RelayState is handled by the server.
 //
 // See: https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf
 // "3.5 HTTP POST Binding"
 type SAMLConnector interface {
-	// POSTData returns an encoded SAML request and SSO URL for the server to
-	// render a POST form with.
+	// AuthnRequest builds an encoded SAML request and SSO URL for the server to
+	// render a POST form or reply a redirection depending on binding.
 	//
-	// POSTData should encode the provided request ID in the returned serialized
+	// AuthnRequest should encode the provided request ID in the returned serialized
 	// SAML request.
-	POSTData(s Scopes, requestID string) (sooURL, samlRequest string, err error)
+	AuthnRequest(s Scopes, requestID string) (binding, ssoURL, samlRequest string, err error)
 
 	// HandlePOST decodes, verifies, and maps attributes from the SAML response.
 	// It passes the expected value of the "InResponseTo" response field, which

--- a/connector/saml/saml_test.go
+++ b/connector/saml/saml_test.go
@@ -53,6 +53,9 @@ type responseTest struct {
 	emailAttr    string
 	groupsAttr   string
 
+	// use redirect binding for response
+	responseUseRedirect bool
+
 	// Expected outcome of the test.
 	wantErr   bool
 	wantIdent connector.Identity
@@ -262,6 +265,27 @@ func TestTwoAssertionFirstSigned(t *testing.T) {
 	test.run(t)
 }
 
+// TestResponseRedirectBinding provides a response for HTTP redirect binding
+func TestResponseRedirectBinding(t *testing.T) {
+	test := responseTest{
+		caFile:       "testdata/ca.crt",
+		respFile:     "testdata/good-resp.xml",
+		now:          "2017-04-04T04:34:59.330Z",
+		usernameAttr: "Name",
+		emailAttr:    "email",
+		inResponseTo: "6zmm5mguyebwvajyf2sdwwcw6m",
+		redirectURI:  "http://127.0.0.1:5556/dex/callback",
+		wantIdent: connector.Identity{
+			UserID:        "eric.chiang+okta@coreos.com",
+			Username:      "Eric",
+			Email:         "eric.chiang+okta@coreos.com",
+			EmailVerified: true,
+		},
+		responseUseRedirect: true,
+	}
+	test.run(t)
+}
+
 func loadCert(ca string) (*x509.Certificate, error) {
 	data, err := ioutil.ReadFile(ca)
 	if err != nil {
@@ -285,6 +309,10 @@ func (r responseTest) run(t *testing.T) {
 		// Never logging in, don't need this.
 		SSOURL: "http://foo.bar/",
 	}
+	if r.responseUseRedirect {
+		c.ResponseBinding = connector.SAMLBindingRedirect
+	}
+
 	now, err := time.Parse(timeFormat, r.now)
 	if err != nil {
 		t.Fatalf("parse test time: %v", err)
@@ -299,13 +327,18 @@ func (r responseTest) run(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if r.responseUseRedirect {
+		if resp, err = deflate(resp); err != nil {
+			t.Fatal(err)
+		}
+	}
 	samlResp := base64.StdEncoding.EncodeToString(resp)
 
 	scopes := connector.Scopes{
 		OfflineAccess: false,
 		Groups:        true,
 	}
-	ident, err := conn.HandlePOST(scopes, samlResp, r.inResponseTo)
+	ident, err := conn.HandleResponse(scopes, samlResp, r.inResponseTo)
 	if err != nil {
 		if !r.wantErr {
 			t.Fatalf("handle response: %v", err)


### PR DESCRIPTION
Update SAML connector config to distinguish protocol bindings for request and response in case the identity provider has specific requirements on these.