### PR TITLE
Makefile: error out if go files aren't correctly formatted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ vet:
 	@go vet $(shell go list ./... | grep -v '/vendor/')
 
 fmt:
-	@go fmt $(shell go list ./... | grep -v '/vendor/')
+	@./scripts/gofmt $(shell go list ./... | grep -v '/vendor/')
 
 lint:
 	@for package in $(shell go list ./... | grep -v '/vendor/' | grep -v '/api' | grep -v '/server/internal'); do \

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -503,13 +503,13 @@ func (c *githubConnector) userEmail(ctx context.Context, client *http.Client) (s
 				advised them not to check for verified emails
 				(https://circleci.com/enterprise/changelog/#1-47-1).
 				In addition, GitHub Enterprise support replied to a support
-				ticket with "There is no way to verify an email address in 
-				GitHub Enterprise."			
+				ticket with "There is no way to verify an email address in
+				GitHub Enterprise."
 			*/
 			if c.hostName != "" {
 				email.Verified = true
 			}
-			
+
 			if email.Verified && email.Primary {
 				return email.Email, nil
 			}

--- a/scripts/gofmt
+++ b/scripts/gofmt
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+result=$( go fmt $@ )
+if [[ $result != "" ]]; then
+    >&2 echo "The following files are not formatted correctly: $result"
+    exit 1
+fi


### PR DESCRIPTION
Noticed in #1058 that our gofmt make target isn't actually erroring
if someone commits misformatted code.