### PR TITLE
storage/kubernetes: Correct the OfflineSession object CRD definition

### DIFF
--- a/storage/kubernetes/types.go
+++ b/storage/kubernetes/types.go
@@ -198,7 +198,7 @@ var customResourceDefinitions = []k8sapi.CustomResourceDefinition{
 			Names: k8sapi.CustomResourceDefinitionNames{
 				Plural:   "offlinesessionses",
 				Singular: "offlinesessions",
-				Kind:     "OfflineSession",
+				Kind:     "OfflineSessions",
 			},
 		},
 	},


### PR DESCRIPTION
Fixes #1070 

OfflineSession object should have the `kind` value as `OfflineSessions` instead of `OfflineSession`. Missed an 's' at the end