### PR TITLE
Groups support for static passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bin
 dist
 _output
+config
+examples/k8s

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 bin
 dist
 _output
-config
-examples/k8s

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+go_import_path: github.com/coreos/dex
 
 sudo: required
 

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -54,6 +54,7 @@ func (p *password) UnmarshalJSON(b []byte) error {
 		Username string `json:"username"`
 		UserID   string `json:"userID"`
 		Hash     string `json:"hash"`
+		Groups   []string `json:"groups"`
 	}
 	if err := json.Unmarshal(b, &data); err != nil {
 		return err
@@ -62,6 +63,7 @@ func (p *password) UnmarshalJSON(b []byte) error {
 		Email:    data.Email,
 		Username: data.Username,
 		UserID:   data.UserID,
+		Groups:   data.Groups,
 	})
 	if len(data.Hash) == 0 {
 		return fmt.Errorf("no password hash provided")

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -50,10 +50,10 @@ type password storage.Password
 
 func (p *password) UnmarshalJSON(b []byte) error {
 	var data struct {
-		Email    string `json:"email"`
-		Username string `json:"username"`
-		UserID   string `json:"userID"`
-		Hash     string `json:"hash"`
+		Email    string   `json:"email"`
+		Username string   `json:"username"`
+		UserID   string   `json:"userID"`
+		Hash     string   `json:"hash"`
 		Groups   []string `json:"groups"`
 	}
 	if err := json.Unmarshal(b, &data); err != nil {

--- a/connector/github/github.go
+++ b/connector/github/github.go
@@ -503,13 +503,13 @@ func (c *githubConnector) userEmail(ctx context.Context, client *http.Client) (s
 				advised them not to check for verified emails
 				(https://circleci.com/enterprise/changelog/#1-47-1).
 				In addition, GitHub Enterprise support replied to a support
-				ticket with "There is no way to verify an email address in 
-				GitHub Enterprise."			
+				ticket with "There is no way to verify an email address in
+				GitHub Enterprise."
 			*/
 			if c.hostName != "" {
 				email.Verified = true
 			}
-			
+
 			if email.Verified && email.Primary {
 				return email.Email, nil
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -281,6 +281,7 @@ type passwordDB struct {
 }
 
 func (db passwordDB) Login(ctx context.Context, s connector.Scopes, email, password string) (connector.Identity, bool, error) {
+
 	p, err := db.s.GetPassword(email)
 	if err != nil {
 		if err != storage.ErrNotFound {
@@ -296,11 +297,13 @@ func (db passwordDB) Login(ctx context.Context, s connector.Scopes, email, passw
 	if err := bcrypt.CompareHashAndPassword(p.Hash, []byte(password)); err != nil {
 		return connector.Identity{}, false, nil
 	}
+
 	return connector.Identity{
 		UserID:        p.UserID,
 		Username:      p.Username,
 		Email:         p.Email,
 		EmailVerified: true,
+		Groups:        p.Groups,
 	}, true, nil
 }
 

--- a/storage/kubernetes/types.go
+++ b/storage/kubernetes/types.go
@@ -112,7 +112,7 @@ type Client struct {
 type ClientList struct {
 	k8sapi.TypeMeta `json:",inline"`
 	k8sapi.ListMeta `json:"metadata,omitempty"`
-	Clients         []Client `json:"items"`
+	Clients []Client `json:"items"`
 }
 
 func (cli *client) fromStorageClient(c storage.Client) Client {
@@ -211,7 +211,7 @@ type AuthRequest struct {
 type AuthRequestList struct {
 	k8sapi.TypeMeta `json:",inline"`
 	k8sapi.ListMeta `json:"metadata,omitempty"`
-	AuthRequests    []AuthRequest `json:"items"`
+	AuthRequests []AuthRequest `json:"items"`
 }
 
 func toStorageAuthRequest(req AuthRequest) storage.AuthRequest {
@@ -259,7 +259,7 @@ func (cli *client) fromStorageAuthRequest(a storage.AuthRequest) AuthRequest {
 	return req
 }
 
-// Password is a mirrored struct from the stroage with JSON struct tags and
+// Password is a mirrored struct from the storage with JSON struct tags and
 // Kubernetes type metadata.
 type Password struct {
 	k8sapi.TypeMeta   `json:",inline"`
@@ -273,13 +273,14 @@ type Password struct {
 	Hash     []byte `json:"hash,omitempty"`
 	Username string `json:"username,omitempty"`
 	UserID   string `json:"userID,omitempty"`
+	Groups   []string `json:"groups,omitempty"`
 }
 
 // PasswordList is a list of Passwords.
 type PasswordList struct {
 	k8sapi.TypeMeta `json:",inline"`
 	k8sapi.ListMeta `json:"metadata,omitempty"`
-	Passwords       []Password `json:"items"`
+	Passwords []Password `json:"items"`
 }
 
 func (cli *client) fromStoragePassword(p storage.Password) Password {
@@ -297,6 +298,7 @@ func (cli *client) fromStoragePassword(p storage.Password) Password {
 		Hash:     p.Hash,
 		Username: p.Username,
 		UserID:   p.UserID,
+		Groups:   p.Groups,
 	}
 }
 
@@ -306,6 +308,7 @@ func toStoragePassword(p Password) storage.Password {
 		Hash:     p.Hash,
 		Username: p.Username,
 		UserID:   p.UserID,
+		Groups:   p.Groups,
 	}
 }
 
@@ -334,7 +337,7 @@ type AuthCode struct {
 type AuthCodeList struct {
 	k8sapi.TypeMeta `json:",inline"`
 	k8sapi.ListMeta `json:"metadata,omitempty"`
-	AuthCodes       []AuthCode `json:"items"`
+	AuthCodes []AuthCode `json:"items"`
 }
 
 func (cli *client) fromStorageAuthCode(a storage.AuthCode) AuthCode {
@@ -397,7 +400,7 @@ type RefreshToken struct {
 type RefreshList struct {
 	k8sapi.TypeMeta `json:",inline"`
 	k8sapi.ListMeta `json:"metadata,omitempty"`
-	RefreshTokens   []RefreshToken `json:"items"`
+	RefreshTokens []RefreshToken `json:"items"`
 }
 
 func toStorageRefreshToken(r RefreshToken) storage.RefreshToken {
@@ -568,5 +571,5 @@ func toStorageConnector(c Connector) storage.Connector {
 type ConnectorList struct {
 	k8sapi.TypeMeta `json:",inline"`
 	k8sapi.ListMeta `json:"metadata,omitempty"`
-	Connectors      []Connector `json:"items"`
+	Connectors []Connector `json:"items"`
 }

--- a/storage/kubernetes/types.go
+++ b/storage/kubernetes/types.go
@@ -112,7 +112,7 @@ type Client struct {
 type ClientList struct {
 	k8sapi.TypeMeta `json:",inline"`
 	k8sapi.ListMeta `json:"metadata,omitempty"`
-	Clients []Client `json:"items"`
+	Clients         []Client `json:"items"`
 }
 
 func (cli *client) fromStorageClient(c storage.Client) Client {
@@ -211,7 +211,7 @@ type AuthRequest struct {
 type AuthRequestList struct {
 	k8sapi.TypeMeta `json:",inline"`
 	k8sapi.ListMeta `json:"metadata,omitempty"`
-	AuthRequests []AuthRequest `json:"items"`
+	AuthRequests    []AuthRequest `json:"items"`
 }
 
 func toStorageAuthRequest(req AuthRequest) storage.AuthRequest {
@@ -270,9 +270,9 @@ type Password struct {
 	// This field is IMMUTABLE. Do not change.
 	Email string `json:"email,omitempty"`
 
-	Hash     []byte `json:"hash,omitempty"`
-	Username string `json:"username,omitempty"`
-	UserID   string `json:"userID,omitempty"`
+	Hash     []byte   `json:"hash,omitempty"`
+	Username string   `json:"username,omitempty"`
+	UserID   string   `json:"userID,omitempty"`
 	Groups   []string `json:"groups,omitempty"`
 }
 
@@ -280,7 +280,7 @@ type Password struct {
 type PasswordList struct {
 	k8sapi.TypeMeta `json:",inline"`
 	k8sapi.ListMeta `json:"metadata,omitempty"`
-	Passwords []Password `json:"items"`
+	Passwords       []Password `json:"items"`
 }
 
 func (cli *client) fromStoragePassword(p storage.Password) Password {
@@ -337,7 +337,7 @@ type AuthCode struct {
 type AuthCodeList struct {
 	k8sapi.TypeMeta `json:",inline"`
 	k8sapi.ListMeta `json:"metadata,omitempty"`
-	AuthCodes []AuthCode `json:"items"`
+	AuthCodes       []AuthCode `json:"items"`
 }
 
 func (cli *client) fromStorageAuthCode(a storage.AuthCode) AuthCode {
@@ -400,7 +400,7 @@ type RefreshToken struct {
 type RefreshList struct {
 	k8sapi.TypeMeta `json:",inline"`
 	k8sapi.ListMeta `json:"metadata,omitempty"`
-	RefreshTokens []RefreshToken `json:"items"`
+	RefreshTokens   []RefreshToken `json:"items"`
 }
 
 func toStorageRefreshToken(r RefreshToken) storage.RefreshToken {
@@ -571,5 +571,5 @@ func toStorageConnector(c Connector) storage.Connector {
 type ConnectorList struct {
 	k8sapi.TypeMeta `json:",inline"`
 	k8sapi.ListMeta `json:"metadata,omitempty"`
-	Connectors []Connector `json:"items"`
+	Connectors      []Connector `json:"items"`
 }

--- a/storage/sql/crud.go
+++ b/storage/sql/crud.go
@@ -553,13 +553,13 @@ func (c *conn) CreatePassword(p storage.Password) error {
 	p.Email = strings.ToLower(p.Email)
 	_, err := c.Exec(`
 		insert into password (
-			email, hash, username, user_id
+			email, hash, username, user_id, groups
 		)
 		values (
-			$1, $2, $3, $4
+			$1, $2, $3, $4, $5
 		);
 	`,
-		p.Email, p.Hash, p.Username, p.UserID,
+		p.Email, p.Hash, p.Username, p.UserID, p.Groups,
 	)
 	if err != nil {
 		if c.alreadyExistsCheck(err) {
@@ -603,7 +603,7 @@ func (c *conn) GetPassword(email string) (storage.Password, error) {
 func getPassword(q querier, email string) (p storage.Password, err error) {
 	return scanPassword(q.QueryRow(`
 		select
-			email, hash, username, user_id
+			email, hash, username, user_id, groups
 		from password where email = $1;
 	`, strings.ToLower(email)))
 }
@@ -611,7 +611,7 @@ func getPassword(q querier, email string) (p storage.Password, err error) {
 func (c *conn) ListPasswords() ([]storage.Password, error) {
 	rows, err := c.Query(`
 		select
-			email, hash, username, user_id
+			email, hash, username, user_id, groups
 		from password;
 	`)
 	if err != nil {

--- a/storage/sql/crud.go
+++ b/storage/sql/crud.go
@@ -559,7 +559,7 @@ func (c *conn) CreatePassword(p storage.Password) error {
 			$1, $2, $3, $4, $5
 		);
 	`,
-		p.Email, p.Hash, p.Username, p.UserID, p.Groups,
+		p.Email, p.Hash, p.Username, p.UserID, encoder(p.Groups),
 	)
 	if err != nil {
 		if c.alreadyExistsCheck(err) {
@@ -584,10 +584,10 @@ func (c *conn) UpdatePassword(email string, updater func(p storage.Password) (st
 		_, err = tx.Exec(`
 			update password
 			set
-				hash = $1, username = $2, user_id = $3
-			where email = $4;
+				hash = $1, username = $2, user_id = $3, groups = $4
+			where email = $5;
 		`,
-			np.Hash, np.Username, np.UserID, p.Email,
+			np.Hash, np.Username, np.UserID, encoder(p.Groups), p.Email,
 		)
 		if err != nil {
 			return fmt.Errorf("update password: %v", err)
@@ -634,7 +634,7 @@ func (c *conn) ListPasswords() ([]storage.Password, error) {
 
 func scanPassword(s scanner) (p storage.Password, err error) {
 	err = s.Scan(
-		&p.Email, &p.Hash, &p.Username, &p.UserID,
+		&p.Email, &p.Hash, &p.Username, &p.UserID, decoder(&p.Groups),
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/storage/sql/migrate.go
+++ b/storage/sql/migrate.go
@@ -190,7 +190,7 @@ var migrations = []migration{
 	{
 		stmt: `
 			alter table password
-				add column groups text;
+				add column groups bytea;
 		`,
 	},
 }

--- a/storage/sql/migrate.go
+++ b/storage/sql/migrate.go
@@ -187,4 +187,10 @@ var migrations = []migration{
 			);
 		`,
 	},
+	{
+		stmt: `
+			alter table password
+				add column groups text;
+		`,
+	},
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -294,7 +294,7 @@ type Password struct {
 	// Randomly generated user ID. This is NOT the primary ID of the Password object.
 	UserID string `json:"userID"`
 
-	// Randomly generated user ID. This is NOT the primary ID of the Password object.
+	// Groups assigned to the user
 	Groups []string `json:"groups"`
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -293,6 +293,9 @@ type Password struct {
 
 	// Randomly generated user ID. This is NOT the primary ID of the Password object.
 	UserID string `json:"userID"`
+
+	// Randomly generated user ID. This is NOT the primary ID of the Password object.
+	Groups []string `json:"groups"`
 }
 
 // Connector is an object that contains the metadata about connectors used to login to Dex.


### PR DESCRIPTION
We would like to configure groups for statically configured users. Currently it is not possible as static passwords do not support this attribute.
This pull request adds support for groups attribute in static passwords.
Additionally I added go_import_path in travis.yaml because I was not able to run tests for my fork in Travis. With go_import_path Travis should work for your project as well as for forks. 