### PR TITLE
Possibility to select a connector in the authorization request.

### DIFF
--- a/Documentation/custom-scopes-claims-clients.md
+++ b/Documentation/custom-scopes-claims-clients.md
@@ -83,6 +83,13 @@ Instead of traditional redirect URIs, public clients are limited to either redir
 
 When using the "out-of-browser" flow, an ID Token nonce is strongly recommended.
 
+## Selecting connector
+
+If multiple connectors are defined DEX displays the page with the list of options. It is possible to skip that step providing connector ID in the authorization request. Sample request using connector with ID `google`:
+
+    GET https://dex-url/auth?connector=google&response_type=code&scope=openid&client_id=testid&redirect_uri=http://localhost/callback
+
+
 [saml-connector]: saml-connector.md
 [core-claims]: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 [standard-claims]: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -174,6 +174,22 @@ func (s *Server) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if authReq.Connector != "" {
+		filtered := connectors[:0]
+		for _, c := range connectors {
+			if c.ID == authReq.Connector {
+				filtered = append(filtered, c)
+			}
+		}
+		if len(filtered) == 0 {
+			s.logger.Errorf("Connection with ID %s not defined", authReq.Connector)
+			s.renderError(w, http.StatusInternalServerError, "Connection "+authReq.Connector+"not found")
+			return
+		}
+		http.Redirect(w, r, s.absPath("/auth", authReq.Connector)+"?req="+authReq.ID, http.StatusFound)
+		return
+	}
+
 	if len(connectors) == 1 {
 		for _, c := range connectors {
 			// TODO(ericchiang): Make this pass on r.URL.RawQuery and let something latter

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/coreos/dex/storage"
 )
 
 func TestHandleHealth(t *testing.T) {
@@ -20,4 +23,50 @@ func TestHandleHealth(t *testing.T) {
 		t.Errorf("expected 200 got %d", rr.Code)
 	}
 
+}
+
+func TestExplicitConnector(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	explicitID := "explicit"
+
+	addConnector := func(c *Config) {
+		connector := storage.Connector{
+			ID:              explicitID,
+			Type:            "mockCallback",
+			Name:            "Mock",
+			ResourceVersion: "1",
+		}
+		if err := c.Storage.CreateConnector(connector); err != nil {
+			t.Fatalf("create connector: %v", err)
+		}
+		redirectURL := "http://localhost/callback"
+		client := storage.Client{
+			ID:           "testid",
+			Secret:       "testsecret",
+			RedirectURIs: []string{redirectURL},
+		}
+		if err := c.Storage.CreateClient(client); err != nil {
+			t.Fatalf("failed to create client: %v", err)
+		}
+
+	}
+
+	httpServer, server := newTestServer(ctx, t, addConnector)
+	defer httpServer.Close()
+
+	authQueryParams := "connector=explicit" +
+		"&response_type=code&scope=openid&client_id=testid&redirect_uri=http://localhost/callback"
+	rr := httptest.NewRecorder()
+	server.handleAuthorization(rr, httptest.NewRequest("GET", "/auth?"+authQueryParams, nil))
+
+	location := rr.Result().Header.Get("location")
+	if !strings.HasPrefix(location, "/auth/"+explicitID) {
+		t.Errorf("expected redirect to /auth/%s, but got %s", explicitID, location)
+	}
+
+	if rr.Code != http.StatusFound {
+		t.Errorf("expected redirect 302 got %d", rr.Code)
+	}
 }

--- a/server/oauth2.go
+++ b/server/oauth2.go
@@ -361,6 +361,7 @@ func (s *Server) parseAuthorizationRequest(r *http.Request) (req storage.AuthReq
 	// Some clients, like the old go-oidc, provide extra whitespace. Tolerate this.
 	scopes := strings.Fields(q.Get("scope"))
 	responseTypes := strings.Fields(q.Get("response_type"))
+	connector := q.Get("connector")
 
 	client, err := s.storage.GetClient(clientID)
 	if err != nil {
@@ -476,6 +477,7 @@ func (s *Server) parseAuthorizationRequest(r *http.Request) (req storage.AuthReq
 		Scopes:              scopes,
 		RedirectURI:         redirectURI,
 		ResponseTypes:       responseTypes,
+		Connector:           connector,
 	}, nil
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -161,6 +161,7 @@ type AuthRequest struct {
 	RedirectURI   string
 	Nonce         string
 	State         string
+	Connector     string
 
 	// The client has indicated that the end user must be shown an approval prompt
 	// on all requests. The server cannot cache their initial action for subsequent


### PR DESCRIPTION
If multiple connectors are defined DEX displays the page with the list of options. This pull request makes it possible to select connector in the authorization request and skip that step. It is similar to the connection parameter in Auth0:
https://auth0.com/docs/api/authentication#social