### PR TITLE
storage/kubernetes: Log before registering custom resources

### DIFF
--- a/storage/kubernetes/storage.go
+++ b/storage/kubernetes/storage.go
@@ -85,6 +85,7 @@ func (c *Config) open(logger logrus.FieldLogger, errOnResources bool) (*client, 
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	logger.Info("creating custom Kubernetes resources")
 	if !cli.registerCustomResources(c.UseTPR) {
 		if errOnResources {
 			cancel()


### PR DESCRIPTION
Logging before attempting to make any connection to Kubernetes is useful when the connection hangs and dex is killed before it can log any errors.