### PR TITLE
Unmarshal `WebConfig` settings

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -86,16 +86,16 @@ type WebConfig struct {
 	//   * templates - HTML templates controlled by dex.
 	//   * themes/(theme) - Static static served at "( issuer URL )/theme".
 	//
-	Dir string
+	Dir string `json:"dir"`
 
 	// Defaults to "( issuer URL )/theme/logo.png"
-	LogoURL string
+	LogoURL string `json:"logourl"`
 
 	// Defaults to "dex"
-	Issuer string
+	Issuer string `json:"issuer"`
 
 	// Defaults to "coreos"
-	Theme string
+	Theme string `json:"theme"`
 }
 
 func value(val, defaultValue time.Duration) time.Duration {


### PR DESCRIPTION
When `frontend` is provided in the configuration, allow Dex to
unmarshal it, so their set properties are effective.

```
frontend:
  dir: /some/dir
  theme: my-theme
```