### PR TITLE
Add support for more OOB templating

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -173,7 +173,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		theme:     c.Web.Theme,
 	}
 
-	static, theme, tmpls, err := loadWebConfig(web)
+	static, theme, tmpls, err := loadWebConfig(web, c.Storage)
 	if err != nil {
 		return nil, fmt.Errorf("server: failed to load web static: %v", err)
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -133,6 +133,15 @@ type Client struct {
 	// Name and LogoURL used when displaying this client to the end user.
 	Name    string `json:"name" yaml:"name"`
 	LogoURL string `json:"logoURL" yaml:"logoURL"`
+
+	// out of band template to use. For use with Public Clients.
+	OOBTemplate string `json:"oobTemplate" yaml:"oobTemplate"`
+
+	// out of band http headers to return. For example, used to force a download.
+	OOBHeaders []map[string]string `json:"oobHeaders" yaml:"oobHeaders"`
+
+	// out of band extra values to pass to the template
+	OOBValues map[string]string `json:"oobValues" yaml:"oobValues"`
 }
 
 // Claims represents the ID Token claims supported by the server.

--- a/web/templates/oob.html
+++ b/web/templates/oob.html
@@ -3,7 +3,7 @@
 <div class="theme-panel">
   <h2 class="theme-heading">Login Successful</h2>
   <p>Please copy this code, switch to your application and paste it there:</p>
-  <input type="text" class="theme-form-input" value="{{ .Code }}" />
+  <input type="text" class="theme-form-input" value="{{ html .Code }}" />
 </div>
 
 {{ template "footer.html" . }}


### PR DESCRIPTION
This PR adds support for templating the OOB support per client, with custom
response headers, and template values. For example, this can be used to
allow the authcode to be returned in a downloadable json file with per
client contact url like so in the config:
  staticClients:
 - name: 'Example App'
    oobHeaders:
    - Content-Type: application/octet-stream
    - Content-Disposition: attachment; filename="bootstrap.json"
    oobTemplate: bootstrap.json
    oobValues:
      server: http://foo.example.com
and template web/templates/bootstrap.json:
{
  "server": "{{ .Values.server }}",
  "authCode": "{{ .Code }}"
}