### PR TITLE
Added User Info endoint for oidc connectors

### DIFF
--- a/Documentation/oidc-connector.md
+++ b/Documentation/oidc-connector.md
@@ -42,6 +42,12 @@ connectors:
     # following field.
     #
     # basicAuthUnsupported: true
+
+    # Some clients require the possibility to get further user details provided
+    # by via the UserInfo endpoint.
+    #
+    # See: http://openid.net/specs/openid-connect-core-1_0.html#UserInfo
+    # userInfo: https://www.googleapis.com/oauth2/v3/userinfo
     
     # Google supports whitelisting allowed domains when using G Suite
     # (Google Apps). The following field can be set to a list of domains

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -65,6 +65,11 @@ type CallbackConnector interface {
 	HandleCallback(s Scopes, r *http.Request) (identity Identity, err error)
 }
 
+// UserInfoConnector represents connectors that support the user info endpoint
+type UserInfoConnector interface {
+	GetUserInfo(connData []byte) (user map[string]interface{}, err error)
+}
+
 // SAMLConnector represents SAML connectors which implement the HTTP POST binding.
 //  RelayState is handled by the server.
 //

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -63,6 +63,7 @@ connectors:
 #   name: Google
 #   config:
 #     issuer: https://accounts.google.com
+#     userInfo: https://www.googleapis.com/oauth2/v3/userinfo
 #     # Connector config values starting with a "$" will read from the environment.
 #     clientID: $GOOGLE_CLIENT_ID
 #     clientSecret: $GOOGLE_CLIENT_SECRET

--- a/server/server.go
+++ b/server/server.go
@@ -239,6 +239,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	// TODO(ericchiang): rate limit certain paths based on IP.
 	handleWithCORS("/token", s.handleToken)
 	handleWithCORS("/keys", s.handlePublicKeys)
+    handleWithCORS("/userinfo", s.handleUserInfo)
 	handleFunc("/auth", s.handleAuthorization)
 	handleFunc("/auth/{connector}", s.handleConnectorLogin)
 	r.HandleFunc(path.Join(issuerURL.Path, "/callback"), func(w http.ResponseWriter, r *http.Request) {

--- a/storage/kubernetes/storage_test.go
+++ b/storage/kubernetes/storage_test.go
@@ -88,6 +88,7 @@ func TestStorage(t *testing.T) {
 	newStorage := func() storage.Storage {
 		for _, resource := range []string{
 			resourceAuthCode,
+			resourceAccessToken,
 			resourceAuthRequest,
 			resourceClient,
 			resourceRefreshToken,

--- a/storage/sql/config_test.go
+++ b/storage/sql/config_test.go
@@ -35,6 +35,7 @@ func cleanDB(c *conn) error {
 		delete from client;
 		delete from auth_request;
 		delete from auth_code;
+		delete from access_token;
 		delete from refresh_token;
 		delete from keys;
 		delete from password;

--- a/storage/sql/migrate.go
+++ b/storage/sql/migrate.go
@@ -121,6 +121,13 @@ var migrations = []migration{
 		
 				expiry timestamptz not null
 			);
+
+			create table access_token (
+				id text not null primary key,
+				connector_id text not null,
+				connector_data blob not null,
+				expiry timestamptz not null
+			);
 		
 			create table refresh_token (
 				id text not null primary key,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -38,6 +38,7 @@ func NewID() string {
 type GCResult struct {
 	AuthRequests int64
 	AuthCodes    int64
+	AccessTokens int64
 }
 
 // Storage is the storage interface used by the server. Implementations are
@@ -50,6 +51,7 @@ type Storage interface {
 	CreateAuthRequest(a AuthRequest) error
 	CreateClient(c Client) error
 	CreateAuthCode(c AuthCode) error
+	CreateAccessToken(c AccessToken) error
 	CreateRefresh(r RefreshToken) error
 	CreatePassword(p Password) error
 	CreateOfflineSessions(s OfflineSessions) error
@@ -59,6 +61,7 @@ type Storage interface {
 	// requests that way instead of using ErrNotFound.
 	GetAuthRequest(id string) (AuthRequest, error)
 	GetAuthCode(id string) (AuthCode, error)
+	GetAccessToken(id string) (AccessToken, error)
 	GetClient(id string) (Client, error)
 	GetKeys() (Keys, error)
 	GetRefresh(id string) (RefreshToken, error)
@@ -74,6 +77,7 @@ type Storage interface {
 	// Delete methods MUST be atomic.
 	DeleteAuthRequest(id string) error
 	DeleteAuthCode(code string) error
+	DeleteAccessToken(id string) error
 	DeleteClient(id string) error
 	DeleteRefresh(id string) error
 	DeletePassword(email string) error
@@ -215,6 +219,22 @@ type AuthCode struct {
 	ConnectorID   string
 	ConnectorData []byte
 	Claims        Claims
+
+	Expiry time.Time
+}
+
+// AccessToken represents all information associated with an access token 
+// which is sent to a client that authenticated with dex
+// This value is stored once once Dex is authenticated with an upstream source
+type AccessToken struct {
+	// Random fake Token sent to the client as if it were the real AccessToken
+	ID string
+
+	// Authorization data provided by an upstream source.
+	ConnectorData []byte
+
+	// The connector this access token is valid for
+	ConnectorID string
 
 	Expiry time.Time
 }


### PR DESCRIPTION
User Info endpoint.
Currently only works with OIDC connector by adding a **userInfo** configuration entry.

Other connectors can make use of the endpoint by implementing the GetUserInfo interface.
Upon login, the connector can store any relevant context information in Identity.connectorData before returning.
This data will be passed back later on as an parameter for the GetUserInfo method.
