### PR TITLE
Added User Info endpoint

### DIFF
--- a/Documentation/oidc-connector.md
+++ b/Documentation/oidc-connector.md
@@ -42,6 +42,12 @@ connectors:
     # following field.
     #
     # basicAuthUnsupported: true
+
+    # Some clients require the possibility to get further user details provided
+    # by via the UserInfo endpoint.
+    #
+    # See: http://openid.net/specs/openid-connect-core-1_0.html#UserInfo
+    # userInfo: https://www.googleapis.com/oauth2/v3/userinfo
     
     # Google supports whitelisting allowed domains when using G Suite
     # (Google Apps). The following field can be set to a list of domains

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -65,6 +65,11 @@ type CallbackConnector interface {
 	HandleCallback(s Scopes, r *http.Request) (identity Identity, err error)
 }
 
+// UserInfoConnector represents connectors that support the user info endpoint
+type UserInfoConnector interface {
+	GetUserInfo(connData []byte) (user map[string]interface{}, err error)
+}
+
 // SAMLConnector represents SAML connectors which implement the HTTP POST binding.
 //  RelayState is handled by the server.
 //

--- a/examples/config-dev.yaml
+++ b/examples/config-dev.yaml
@@ -63,6 +63,7 @@ connectors:
 #   name: Google
 #   config:
 #     issuer: https://accounts.google.com
+#     userInfo: https://www.googleapis.com/oauth2/v3/userinfo
 #     # Connector config values starting with a "$" will read from the environment.
 #     clientID: $GOOGLE_CLIENT_ID
 #     clientSecret: $GOOGLE_CLIENT_SECRET

--- a/server/server.go
+++ b/server/server.go
@@ -239,6 +239,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 	// TODO(ericchiang): rate limit certain paths based on IP.
 	handleWithCORS("/token", s.handleToken)
 	handleWithCORS("/keys", s.handlePublicKeys)
+    handleWithCORS("/userinfo", s.handleUserInfo)
 	handleFunc("/auth", s.handleAuthorization)
 	handleFunc("/auth/{connector}", s.handleConnectorLogin)
 	r.HandleFunc(path.Join(issuerURL.Path, "/callback"), func(w http.ResponseWriter, r *http.Request) {

--- a/storage/conformance/conformance.go
+++ b/storage/conformance/conformance.go
@@ -42,6 +42,7 @@ func runTests(t *testing.T, newStorage func() storage.Storage, tests []subTest) 
 func RunTests(t *testing.T, newStorage func() storage.Storage) {
 	runTests(t, newStorage, []subTest{
 		{"AuthCodeCRUD", testAuthCodeCRUD},
+		{"AccessTokenCRUD", testAccessTokenCRUD},
 		{"AuthRequestCRUD", testAuthRequestCRUD},
 		{"ClientCRUD", testClientCRUD},
 		{"RefreshTokenCRUD", testRefreshTokenCRUD},
@@ -236,6 +237,57 @@ func testAuthCodeCRUD(t *testing.T, s storage.Storage) {
 
 	_, err = s.GetAuthCode(a1.ID)
 	mustBeErrNotFound(t, "auth code", err)
+}
+
+func testAccessTokenCRUD(t *testing.T, s storage.Storage) {
+	a1 := storage.AccessToken{
+		ID:            storage.NewID(),
+		ConnectorData: []byte(`{"some":"data"}`),
+		ConnectorID:   "ldap",
+		Expiry:        neverExpire,
+	}
+
+	if err := s.CreateAccessToken(a1); err != nil {
+		t.Fatalf("failed creating access token: %v", err)
+	}
+
+	a2 := storage.AccessToken{
+		ID:            storage.NewID(),
+		ConnectorData: []byte(`{"some":"data"}`),
+		ConnectorID:   "ldap",
+		Expiry:        neverExpire,
+	}
+
+	// Attempt to create same AccessToken twice.
+	err := s.CreateAccessToken(a1)
+	mustBeErrAlreadyExists(t, "access token", err)
+
+	if err := s.CreateAccessToken(a2); err != nil {
+		t.Fatalf("failed creating access token: %v", err)
+	}
+
+	got, err := s.GetAccessToken(a1.ID)
+	if err != nil {
+		t.Fatalf("failed to get access token: %v", err)
+	}
+	if a1.Expiry.Unix() != got.Expiry.Unix() {
+		t.Errorf("access token expiry did not match want=%s vs got=%s", a1.Expiry, got.Expiry)
+	}
+	got.Expiry = a1.Expiry // time fields do not compare well
+	if diff := pretty.Compare(a1, got); diff != "" {
+		t.Errorf("access token retrieved from storage did not match: %s", diff)
+	}
+
+	if err := s.DeleteAccessToken(a1.ID); err != nil {
+		t.Fatalf("delete access token: %v", err)
+	}
+
+	if err := s.DeleteAccessToken(a2.ID); err != nil {
+		t.Fatalf("delete access token: %v", err)
+	}
+
+	_, err = s.GetAccessToken(a1.ID)
+	mustBeErrNotFound(t, "access token", err)
 }
 
 func testClientCRUD(t *testing.T, s storage.Storage) {
@@ -731,7 +783,7 @@ func testGC(t *testing.T, s storage.Storage) {
 		if err != nil {
 			t.Errorf("garbage collection failed: %v", err)
 		} else {
-			if result.AuthCodes != 0 || result.AuthRequests != 0 {
+			if result.AuthCodes != 0 || result.AccessTokens != 0 || result.AuthRequests != 0 {
 				t.Errorf("expected no garbage collection results, got %#v", result)
 			}
 		}
@@ -748,6 +800,43 @@ func testGC(t *testing.T, s storage.Storage) {
 
 	if _, err := s.GetAuthCode(c.ID); err == nil {
 		t.Errorf("expected auth code to be GC'd")
+	} else if err != storage.ErrNotFound {
+		t.Errorf("expected storage.ErrNotFound, got %v", err)
+	}
+
+	b := storage.AccessToken{
+		ID:            storage.NewID(),
+		ConnectorData: []byte(`{"some":"data"}`),
+		ConnectorID:   "ldap",
+		Expiry:        expiry,
+	}
+
+	if err := s.CreateAccessToken(b); err != nil {
+		t.Fatalf("failed creating access token: %v", err)
+	}
+
+	for _, tz := range []*time.Location{time.UTC, est, pst} {
+		result, err := s.GarbageCollect(expiry.Add(-time.Hour).In(tz))
+		if err != nil {
+			t.Errorf("garbage collection failed: %v", err)
+		} else {
+			if result.AccessTokens != 0 || result.AccessTokens != 0 || result.AuthRequests != 0 {
+				t.Errorf("expected no garbage collection results, got %#v", result)
+			}
+		}
+		if _, err := s.GetAccessToken(b.ID); err != nil {
+			t.Errorf("expected to be able to get access token after GC: %v", err)
+		}
+	}
+
+	if r, err := s.GarbageCollect(expiry.Add(time.Hour)); err != nil {
+		t.Errorf("garbage collection failed: %v", err)
+	} else if r.AccessTokens != 1 {
+		t.Errorf("expected to garbage collect 1 objects, got %d", r.AccessTokens)
+	}
+
+	if _, err := s.GetAccessToken(b.ID); err == nil {
+		t.Errorf("expected access token to be GC'd")
 	} else if err != storage.ErrNotFound {
 		t.Errorf("expected storage.ErrNotFound, got %v", err)
 	}
@@ -783,7 +872,7 @@ func testGC(t *testing.T, s storage.Storage) {
 		if err != nil {
 			t.Errorf("garbage collection failed: %v", err)
 		} else {
-			if result.AuthCodes != 0 || result.AuthRequests != 0 {
+			if result.AuthCodes != 0 || result.AccessTokens != 0 || result.AuthRequests != 0 {
 				t.Errorf("expected no garbage collection results, got %#v", result)
 			}
 		}

--- a/storage/kubernetes/storage_test.go
+++ b/storage/kubernetes/storage_test.go
@@ -88,6 +88,7 @@ func TestStorage(t *testing.T) {
 	newStorage := func() storage.Storage {
 		for _, resource := range []string{
 			resourceAuthCode,
+			resourceAccessToken,
 			resourceAuthRequest,
 			resourceClient,
 			resourceRefreshToken,

--- a/storage/sql/config_test.go
+++ b/storage/sql/config_test.go
@@ -35,6 +35,7 @@ func cleanDB(c *conn) error {
 		delete from client;
 		delete from auth_request;
 		delete from auth_code;
+		delete from access_token;
 		delete from refresh_token;
 		delete from keys;
 		delete from password;

--- a/storage/sql/migrate.go
+++ b/storage/sql/migrate.go
@@ -121,6 +121,13 @@ var migrations = []migration{
 		
 				expiry timestamptz not null
 			);
+
+			create table access_token (
+				id text not null primary key,
+				connector_id text not null,
+				connector_data blob not null,
+				expiry timestamptz not null
+			);
 		
 			create table refresh_token (
 				id text not null primary key,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -38,6 +38,7 @@ func NewID() string {
 type GCResult struct {
 	AuthRequests int64
 	AuthCodes    int64
+	AccessTokens int64
 }
 
 // Storage is the storage interface used by the server. Implementations are
@@ -50,6 +51,7 @@ type Storage interface {
 	CreateAuthRequest(a AuthRequest) error
 	CreateClient(c Client) error
 	CreateAuthCode(c AuthCode) error
+	CreateAccessToken(c AccessToken) error
 	CreateRefresh(r RefreshToken) error
 	CreatePassword(p Password) error
 	CreateOfflineSessions(s OfflineSessions) error
@@ -59,6 +61,7 @@ type Storage interface {
 	// requests that way instead of using ErrNotFound.
 	GetAuthRequest(id string) (AuthRequest, error)
 	GetAuthCode(id string) (AuthCode, error)
+	GetAccessToken(id string) (AccessToken, error)
 	GetClient(id string) (Client, error)
 	GetKeys() (Keys, error)
 	GetRefresh(id string) (RefreshToken, error)
@@ -74,6 +77,7 @@ type Storage interface {
 	// Delete methods MUST be atomic.
 	DeleteAuthRequest(id string) error
 	DeleteAuthCode(code string) error
+	DeleteAccessToken(id string) error
 	DeleteClient(id string) error
 	DeleteRefresh(id string) error
 	DeletePassword(email string) error
@@ -215,6 +219,22 @@ type AuthCode struct {
 	ConnectorID   string
 	ConnectorData []byte
 	Claims        Claims
+
+	Expiry time.Time
+}
+
+// AccessToken represents all information associated with an access token 
+// which is sent to a client that authenticated with dex
+// This value is stored once once Dex is authenticated with an upstream source
+type AccessToken struct {
+	// Random fake Token sent to the client as if it were the real AccessToken
+	ID string
+
+	// Authorization data provided by an upstream source.
+	ConnectorData []byte
+
+	// The connector this access token is valid for
+	ConnectorID string
 
 	Expiry time.Time
 }


### PR DESCRIPTION
Currently only works with OIDC connector by adding a userInfo configuration entry, but ready to be implemented for other connectors.

Other connectors can make use of the endpoint by implementing the GetUserInfo interface.
Upon login, the connector can store any relevant context information in Identity.connectorData before returning.
This data will be passed back later on as an parameter for the GetUserInfo method.