### PR TITLE
connector/oidc: remove test that talks to the internet

### DIFF
--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -1,13 +1,7 @@
 package oidc
 
 import (
-	"net/url"
-	"os"
-	"reflect"
 	"testing"
-
-	"github.com/coreos/dex/connector"
-	"github.com/sirupsen/logrus"
 )
 
 func TestKnownBrokenAuthHeaderProvider(t *testing.T) {
@@ -29,95 +23,3 @@ func TestKnownBrokenAuthHeaderProvider(t *testing.T) {
 		}
 	}
 }
-
-func TestOidcConnector_LoginURL(t *testing.T) {
-	logger := &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: &logrus.TextFormatter{DisableColors: true},
-		Level:     logrus.DebugLevel,
-	}
-
-	tests := []struct {
-		scopes        connector.Scopes
-		hostedDomains []string
-
-		wantScopes  string
-		wantHdParam string
-	}{
-		{
-			connector.Scopes{}, []string{"example.com"},
-			"openid profile email", "example.com",
-		},
-		{
-			connector.Scopes{}, []string{"mydomain.org", "example.com"},
-			"openid profile email", "*",
-		},
-		{
-			connector.Scopes{}, []string{},
-			"openid profile email", "",
-		},
-		{
-			connector.Scopes{OfflineAccess: true}, []string{},
-			"openid profile email", "",
-		},
-	}
-
-	callback := "https://dex.example.com/callback"
-	state := "secret"
-
-	for _, test := range tests {
-		config := &Config{
-			Issuer:        "https://accounts.google.com",
-			ClientID:      "client-id",
-			ClientSecret:  "client-secret",
-			RedirectURI:   "https://dex.example.com/callback",
-			HostedDomains: test.hostedDomains,
-		}
-
-		conn, err := config.Open("oidc", logger)
-		if err != nil {
-			t.Errorf("failed to open connector: %v", err)
-			continue
-		}
-
-		loginURL, err := conn.(connector.CallbackConnector).LoginURL(test.scopes, callback, state)
-		if err != nil {
-			t.Errorf("failed to get login URL: %v", err)
-			continue
-		}
-
-		actual, err := url.Parse(loginURL)
-		if err != nil {
-			t.Errorf("failed to parse login URL: %v", err)
-			continue
-		}
-
-		wanted, _ := url.Parse("https://accounts.google.com/o/oauth2/v2/auth")
-		wantedQuery := &url.Values{}
-		wantedQuery.Set("client_id", config.ClientID)
-		wantedQuery.Set("redirect_uri", config.RedirectURI)
-		wantedQuery.Set("response_type", "code")
-		wantedQuery.Set("state", "secret")
-		wantedQuery.Set("scope", test.wantScopes)
-		if test.wantHdParam != "" {
-			wantedQuery.Set("hd", test.wantHdParam)
-		}
-		wanted.RawQuery = wantedQuery.Encode()
-
-		if !reflect.DeepEqual(actual, wanted) {
-			t.Errorf("Wanted %v, got %v", wanted, actual)
-		}
-	}
-}
-
-//func TestOidcConnector_HandleCallback(t *testing.T) {
-//	logger := &logrus.Logger{
-//		Out:       os.Stderr,
-//		Formatter: &logrus.TextFormatter{DisableColors: true},
-//		Level:     logrus.DebugLevel,
-//	}
-//
-//	tests := []struct {
-//
-//	}
-//}


### PR DESCRIPTION
Notice this flake here https://travis-ci.org/coreos/dex/jobs/293766424

Unit tests shouldn't talk to the internet.

```
=== RUN   TestOidcConnector_LoginURL
--- FAIL: TestOidcConnector_LoginURL (30.47s)
	oidc_test.go:79: failed to open connector: failed to get provider: Get https://accounts.google.com/.well-known/openid-configuration: dial tcp 108.177.10.84:443: i/o timeout
```

@roguePanda noticed this was added in https://github.com/coreos/dex/pull/974. Removing it for now. If you'd like to follow up with a PR to add the test back in please do.

cc @rithujohn191 