### PR TITLE
Add tectonic-ldap matching rule to ldap icon.

### DIFF
--- a/web/static/main.css
+++ b/web/static/main.css
@@ -73,7 +73,7 @@ body {
   background-image: url(../static/img/bitbucket-icon.svg);
 }
 
-.dex-btn-icon--ldap {
+.dex-btn-icon--ldap, .dex-btn-icon--tectonic-ldap {
   background-color: #84B6EF;
   background-image: url(../static/img/ldap-icon.svg);
 }


### PR DESCRIPTION
Fixes an issue where the ldap icon was missing in the tectonic console.

I think the long-term fix would be to change the login template to add classes based on the connector type, not the connector ID. That requires some bigger changes though.