### PR TITLE
show "back" link for password connectors

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -223,6 +223,7 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	scopes := parseScopes(authReq.Scopes)
+	showBacklink := len(s.connectors) > 1
 
 	switch r.Method {
 	case "GET":
@@ -250,7 +251,7 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 			}
 			http.Redirect(w, r, callbackURL, http.StatusFound)
 		case connector.PasswordConnector:
-			if err := s.templates.password(w, r.URL.String(), "", usernamePrompt(conn), false); err != nil {
+			if err := s.templates.password(w, r.URL.String(), "", usernamePrompt(conn), false, showBacklink); err != nil {
 				s.logger.Errorf("Server template error: %v", err)
 			}
 		case connector.SAMLConnector:
@@ -298,7 +299,7 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !ok {
-			if err := s.templates.password(w, r.URL.String(), username, usernamePrompt(passwordConnector), true); err != nil {
+			if err := s.templates.password(w, r.URL.String(), username, usernamePrompt(passwordConnector), true, showBacklink); err != nil {
 				s.logger.Errorf("Server template error: %v", err)
 			}
 			return

--- a/server/templates.go
+++ b/server/templates.go
@@ -190,13 +190,14 @@ func (t *templates) login(w http.ResponseWriter, connectors []connectorInfo) err
 	return renderTemplate(w, t.loginTmpl, data)
 }
 
-func (t *templates) password(w http.ResponseWriter, postURL, lastUsername, usernamePrompt string, lastWasInvalid bool) error {
+func (t *templates) password(w http.ResponseWriter, postURL, lastUsername, usernamePrompt string, lastWasInvalid, showBacklink bool) error {
 	data := struct {
 		PostURL        string
+		BackLink       bool
 		Username       string
 		UsernamePrompt string
 		Invalid        bool
-	}{postURL, lastUsername, usernamePrompt, lastWasInvalid}
+	}{postURL, showBacklink, lastUsername, usernamePrompt, lastWasInvalid}
 	return renderTemplate(w, t.passwordTmpl, data)
 }
 

--- a/web/templates/password.html
+++ b/web/templates/password.html
@@ -25,6 +25,11 @@
     <button tabindex="3" id="submit-login" type="submit" class="dex-btn theme-btn--primary">Login</button>
 
   </form>
+  {{ if .BackLink }}
+  <div class="theme-link-back">
+    <a class="dex-subtle-text" href="javascript:history.back()">Select another login method.</a>
+  </div>
+  {{ end }}
 </div>
 
 {{ template "footer.html" . }}

--- a/web/themes/coreos/styles.css
+++ b/web/themes/coreos/styles.css
@@ -107,3 +107,7 @@
   text-align: left;
   width: 250px;
 }
+
+.theme-link-back {
+  margin-top: 4px;
+}


### PR DESCRIPTION
This way, the user who has selected, say, "Log in with Email" can make up
their mind, and select a different connector instead.

However, if there's only one connector set up, none of this makes sense -- and
the link will thus not be displayed.

<img width="516" alt="screen shot 2017-11-09 at 16 18 25" src="https://user-images.githubusercontent.com/870638/32613027-0d76c318-c56a-11e7-8e9d-457251775388.png">

Fixes #1115.