### PR TITLE
README.md: remove milestones link

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ Due to their public nature, GitHub and mailing lists are NOT appropriate places 
 
 * For feature requests and bugs, file an [issue][issues].
 * For general discussion about both using and developing dex, join the [dex-dev][dex-dev] mailing list.
-* For more details on dex development plans, check out the GitHub [milestones][milestones].
 
 [openid-connect]: https://openid.net/connect/
 [standard-claims]: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
@@ -93,5 +92,4 @@ Due to their public nature, GitHub and mailing lists are NOT appropriate places 
 [go-oidc]: https://github.com/coreos/go-oidc
 [issues]: https://github.com/coreos/dex/issues
 [dex-dev]: https://groups.google.com/forum/#!forum/dex-dev
-[milestones]: https://github.com/coreos/dex/milestones
 [disclosure]: https://coreos.com/security/disclosure/


### PR DESCRIPTION
We haven't been using milestones or actively planning sprints for dex lately. It's probably better to just remove this.

Closes https://github.com/coreos/dex/issues/1122

