### PR TITLE
Specify Java package for dex Protobuf API

### DIFF
--- a/api/api.proto
+++ b/api/api.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+option java_package = "com.coreos.dex.api";
 
 package api;
 


### PR DESCRIPTION
It would be good to have a stable package name for consistency.