### PR TITLE
Bugfix: Set a proper status code before sending an error status page

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -996,7 +996,7 @@ func (s *Server) writeAccessToken(w http.ResponseWriter, idToken, accessToken, r
 }
 
 func (s *Server) renderError(w http.ResponseWriter, status int, description string) {
-	if err := s.templates.err(w, http.StatusText(status), description); err != nil {
+	if err := s.templates.err(w, status, description); err != nil {
 		s.logger.Errorf("Server template error: %v", err)
 	}
 }

--- a/server/templates.go
+++ b/server/templates.go
@@ -226,12 +226,16 @@ func (t *templates) oob(w http.ResponseWriter, code string) error {
 	return renderTemplate(w, t.oobTmpl, data)
 }
 
-func (t *templates) err(w http.ResponseWriter, errType string, errMsg string) error {
+func (t *templates) err(w http.ResponseWriter, errCode int, errMsg string) error {
+	w.WriteHeader(errCode)
 	data := struct {
 		ErrType string
 		ErrMsg  string
-	}{errType, errMsg}
-	return renderTemplate(w, t.errorTmpl, data)
+	}{http.StatusText(errCode), errMsg}
+	if err := t.errorTmpl.Execute(w, data); err != nil {
+		return fmt.Errorf("Error rendering template %s: %s", t.errorTmpl.Name(), err)
+	}
+	return nil
 }
 
 // small io.Writer utility to determine if executing the template wrote to the underlying response writer.


### PR DESCRIPTION
We are facing an problem in health-checking a dex service. The health-check endpoint provided by dex always returns with HTTP status code 200 even if it is returning an error status page.

The function which renders an error page doesn't seem to take care of HTTP status code. This PR will fix the function to set a proper status code before sending contents.