### PR TITLE
handlers/connector_login: update AuthRequest irregardless of method

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -224,14 +224,16 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Set the connector being used for the login.
-	updater := func(a storage.AuthRequest) (storage.AuthRequest, error) {
-		a.ConnectorID = connID
-		return a, nil
-	}
-	if err := s.storage.UpdateAuthRequest(authReqID, updater); err != nil {
-		s.logger.Errorf("Failed to set connector ID on auth request: %v", err)
-		s.renderError(w, http.StatusInternalServerError, "Database error.")
-		return
+	if authReq.ConnectorID != connID {
+		updater := func(a storage.AuthRequest) (storage.AuthRequest, error) {
+			a.ConnectorID = connID
+			return a, nil
+		}
+		if err := s.storage.UpdateAuthRequest(authReqID, updater); err != nil {
+			s.logger.Errorf("Failed to set connector ID on auth request: %v", err)
+			s.renderError(w, http.StatusInternalServerError, "Database error.")
+			return
+		}
 	}
 
 	scopes := parseScopes(authReq.Scopes)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -222,22 +222,23 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+
+	// Set the connector being used for the login.
+	updater := func(a storage.AuthRequest) (storage.AuthRequest, error) {
+		a.ConnectorID = connID
+		return a, nil
+	}
+	if err := s.storage.UpdateAuthRequest(authReqID, updater); err != nil {
+		s.logger.Errorf("Failed to set connector ID on auth request: %v", err)
+		s.renderError(w, http.StatusInternalServerError, "Database error.")
+		return
+	}
+
 	scopes := parseScopes(authReq.Scopes)
 	showBacklink := len(s.connectors) > 1
 
 	switch r.Method {
 	case "GET":
-		// Set the connector being used for the login.
-		updater := func(a storage.AuthRequest) (storage.AuthRequest, error) {
-			a.ConnectorID = connID
-			return a, nil
-		}
-		if err := s.storage.UpdateAuthRequest(authReqID, updater); err != nil {
-			s.logger.Errorf("Failed to set connector ID on auth request: %v", err)
-			s.renderError(w, http.StatusInternalServerError, "Database error.")
-			return
-		}
-
 		switch conn := conn.Connector.(type) {
 		case connector.CallbackConnector:
 			// Use the auth request ID as the "state" token.


### PR DESCRIPTION
Before, you could not POST your credentials to a password-connector's
endpoint without GETing that endpoint first. While this makes sense for
browser clients; automated interactions with Dex don't need to look at
the password form to fill it in.

A symptom of that missing GET was that the POST succeeded (!) with

    login successful: connector "", username="admin", email="admin@example.com", groups=[]

Note the connector "". A subsequent call to finalizeLogin would then
fail with

    connector with ID "" not found: failed to get connector object from storage: not found

Now, the connector ID of an auth request will be updated for both GETs
and POSTs.