### PR TITLE
Clarify email scope description

### DIFF
--- a/server/templates.go
+++ b/server/templates.go
@@ -167,7 +167,7 @@ func loadTemplates(c webConfig, templatesDir string) (*templates, error) {
 var scopeDescriptions = map[string]string{
 	"offline_access": "Have offline access",
 	"profile":        "View basic profile information",
-	"email":          "View your email",
+	"email":          "View your email address",
 }
 
 type connectorInfo struct {


### PR DESCRIPTION
Hey all. This is an update to the description of the "email" scope that clarifies that it only grants access to view the user's email _address_ rather than their actual emails.