### PR TITLE
[WIP] PKI (two way TLS) auth support

### DIFF
--- a/cmd/example-app/main.go
+++ b/cmd/example-app/main.go
@@ -43,6 +43,9 @@ type app struct {
 // return an HTTP client which trusts the provided root CAs.
 func httpClientForRootCAs(rootCAs string) (*http.Client, error) {
 	tlsConfig := tls.Config{RootCAs: x509.NewCertPool()}
+	tlsConfig.ServerName = "127.0.0.1:5556"
+	//tlsConfig.ServerName = "127.0.0.1"
+	tlsConfig.ServerName = "twl-server-generic2"
 	rootCABytes, err := ioutil.ReadFile(rootCAs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read root-ca: %v", err)
@@ -195,7 +198,7 @@ func cmd() *cobra.Command {
 	c.Flags().StringVar(&a.clientID, "client-id", "example-app", "OAuth2 client ID of this application.")
 	c.Flags().StringVar(&a.clientSecret, "client-secret", "ZXhhbXBsZS1hcHAtc2VjcmV0", "OAuth2 client secret of this application.")
 	c.Flags().StringVar(&a.redirectURI, "redirect-uri", "http://127.0.0.1:5555/callback", "Callback URL for OAuth2 responses.")
-	c.Flags().StringVar(&issuerURL, "issuer", "http://127.0.0.1:5556/dex", "URL of the OpenID Connect issuer.")
+	c.Flags().StringVar(&issuerURL, "issuer", "https://127.0.0.1:5556/dex", "URL of the OpenID Connect issuer.")
 	c.Flags().StringVar(&listen, "listen", "http://127.0.0.1:5555", "HTTP(S) address to listen at.")
 	c.Flags().StringVar(&tlsCert, "tls-cert", "", "X509 cert file to present when serving HTTPS.")
 	c.Flags().StringVar(&tlsKey, "tls-key", "", "Private key for the HTTPS cert.")
@@ -304,6 +307,8 @@ func (a *app) handleCallback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "no id_token in token response", http.StatusInternalServerError)
 		return
 	}
+
+	log.Println("RAW ID:", rawIDToken)
 
 	idToken, err := a.verifier.Verify(r.Context(), rawIDToken)
 	if err != nil {

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -35,6 +35,8 @@ type Identity struct {
 	//
 	// This data is never shared with end users, OAuth clients, or through the API.
 	ConnectorData []byte
+
+	UserDN string
 }
 
 // PasswordConnector is an interface implemented by connectors which take a
@@ -45,6 +47,11 @@ type PasswordConnector interface {
 	Prompt() string
 	Login(ctx context.Context, s Scopes, username, password string) (identity Identity, validPassword bool, err error)
 }
+
+//type PKIConnector interface {
+//	Prompt() string
+//	Login(ctx context.Context, s Scopes, dn string) (identity Identity, err error)
+//}
 
 // CallbackConnector is an interface implemented by connectors which use an OAuth
 // style redirect flow to determine user information.

--- a/connector/pki/pki.go
+++ b/connector/pki/pki.go
@@ -1,0 +1,89 @@
+package pki
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/coreos/dex/connector"
+	"github.com/sirupsen/logrus"
+	"github.com/coreos/dex/pkiutil"
+)
+
+// Config holds configuration options for pki logins.
+type Config struct {
+	// RedirectURI string `json:"redirectURI"`
+}
+
+// Open returns a strategy for logging in through GitHub.
+func (c *Config) Open(id string, logger logrus.FieldLogger) (connector.Connector, error) {
+	p := pkiConnector{
+		logger: logger,
+	}
+
+	return &p, nil
+}
+
+type connectorData struct {
+	// GitHub's OAuth2 tokens never expire. We don't need a refresh token.
+	AccessToken string `json:"accessToken"`
+}
+
+var (
+	_ connector.PasswordConnector = (*pkiConnector)(nil)
+	_ connector.RefreshConnector  = (*pkiConnector)(nil)
+)
+
+type pkiConnector struct {
+	logger logrus.FieldLogger
+}
+
+type refreshData struct {
+	DN string `json:"dn"`
+}
+
+func (c *pkiConnector) Prompt() string {
+	return "PROMPT"
+}
+
+func (c *pkiConnector) Login(ctx context.Context, s connector.Scopes, username, password string) (identity connector.Identity, validPass bool, err error) {
+	dn, ok := pkiutil.DistinguishedNameFromContext(ctx)
+	if !ok {
+		return connector.Identity{}, false, fmt.Errorf("pki: no peer certificate found")
+	}
+
+	identity.UserID = dn
+	identity.UserDN = dn
+
+	if s.OfflineAccess {
+		refresh := refreshData{
+			DN: dn,
+		}
+		if identity.ConnectorData, err = json.Marshal(refresh); err != nil {
+			return connector.Identity{}, false, fmt.Errorf("pki: marshal entry: %v", err)
+		}
+	}
+
+	return identity, true, nil
+}
+
+func (c *pkiConnector) Refresh(ctx context.Context, s connector.Scopes, identity connector.Identity) (connector.Identity, error) {
+	dn, ok := pkiutil.DistinguishedNameFromContext(ctx)
+	if !ok {
+		return connector.Identity{}, fmt.Errorf("pki: no peer certificate found")
+	}
+
+	var data refreshData
+	if err := json.Unmarshal(identity.ConnectorData, &data); err != nil {
+		return connector.Identity{}, fmt.Errorf("pki: failed to unamrshal internal data: %v", err)
+	}
+
+	if data.DN != dn {
+		return connector.Identity{}, fmt.Errorf("pki: refresh expected DN %q but got %q", data.DN, dn)
+	}
+
+	//identity.Email = TODO (???)
+	identity.UserID = dn
+	identity.UserDN = dn
+
+	return identity, nil
+}

--- a/examples/config-pki.yaml
+++ b/examples/config-pki.yaml
@@ -14,11 +14,11 @@ storage:
 
 # Configuration for the HTTP endpoints.
 web:
-  http: 0.0.0.0:5556
+  #http: 0.0.0.0:5556
   # Uncomment for HTTPS options.
-  # https: 127.0.0.1:5554
-  # tlsCert: /etc/dex/tls.crt
-  # tlsKey: /etc/dex/tls.key
+  https: 127.0.0.1:5556
+  tlsCert: /etc/dex/tls.crt
+  tlsKey: /etc/dex/tls.key
 
 # Configuration for telemetry
 telemetry:
@@ -59,9 +59,9 @@ staticClients:
   secret: ZXhhbXBsZS1hcHAtc2VjcmV0
 
 connectors:
-- type: mockCallback
-  id: mock
-  name: Example
+- type: pki
+  id: pki
+  name: PKI
 # - type: oidc
 #   id: google
 #   name: Google

--- a/pkiutil/pkiutil.go
+++ b/pkiutil/pkiutil.go
@@ -1,0 +1,16 @@
+package pkiutil
+
+import "context"
+
+type key struct{}
+
+var dnKey = key{}
+
+func ContextWithDistinguishedName(parent context.Context, dn string) context.Context {
+	return context.WithValue(parent, dnKey, dn)
+}
+
+func DistinguishedNameFromContext(ctx context.Context) (dn string, ok bool) {
+	u, ok := ctx.Value(dnKey).(string)
+	return u, ok
+}

--- a/scripts/check-go-version
+++ b/scripts/check-go-version
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 

--- a/scripts/dump-tprs
+++ b/scripts/dump-tprs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 

--- a/scripts/get-protoc
+++ b/scripts/get-protoc
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 # This is a script to download protoc. Rather than depending on the version on
 # a developer's machine, always download a specific version.

--- a/scripts/git-diff
+++ b/scripts/git-diff
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 DIFF=$( git diff . )
 if [ "$DIFF" != "" ]; then

--- a/scripts/gofmt
+++ b/scripts/gofmt
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 result=$( go fmt $@ )
 if [[ $result != "" ]]; then

--- a/scripts/test-k8s.sh
+++ b/scripts/test-k8s.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 TEMPDIR=$( mktemp -d )
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	jose "gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2"
 
 	"github.com/coreos/dex/connector"
 	"github.com/coreos/dex/server/internal"
@@ -406,6 +406,7 @@ func (s *Server) finalizeLogin(identity connector.Identity, authReq storage.Auth
 		Email:         identity.Email,
 		EmailVerified: identity.EmailVerified,
 		Groups:        identity.Groups,
+		UserDN:        identity.UserDN,
 	}
 
 	updater := func(a storage.AuthRequest) (storage.AuthRequest, error) {
@@ -880,6 +881,7 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request, clie
 		Email:         refresh.Claims.Email,
 		EmailVerified: refresh.Claims.EmailVerified,
 		Groups:        refresh.Claims.Groups,
+		UserDN:        refresh.Claims.UserDN,
 		ConnectorData: refresh.ConnectorData,
 	}
 
@@ -904,6 +906,7 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request, clie
 		Email:         ident.Email,
 		EmailVerified: ident.EmailVerified,
 		Groups:        ident.Groups,
+		UserDN:        ident.UserDN,
 	}
 
 	accessToken := storage.NewID()
@@ -938,6 +941,7 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request, clie
 		old.Claims.Email = ident.Email
 		old.Claims.EmailVerified = ident.EmailVerified
 		old.Claims.Groups = ident.Groups
+		old.Claims.UserDN = ident.UserDN
 		old.ConnectorData = ident.ConnectorData
 		old.LastUsed = lastUsed
 		return old, nil

--- a/server/server.go
+++ b/server/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/coreos/dex/connector/oidc"
 	"github.com/coreos/dex/connector/saml"
 	"github.com/coreos/dex/storage"
+	"github.com/coreos/dex/connector/pki"
 )
 
 // LocalConnector is the local passwordDB connector which is an internal
@@ -439,6 +440,7 @@ var ConnectorsConfig = map[string]func() ConnectorConfig{
 	"authproxy":    func() ConnectorConfig { return new(authproxy.Config) },
 	"linkedin":     func() ConnectorConfig { return new(linkedin.Config) },
 	"microsoft":    func() ConnectorConfig { return new(microsoft.Config) },
+	"pki":          func() ConnectorConfig { return new(pki.Config) },
 	// Keep around for backwards compatibility.
 	"samlExperimental": func() ConnectorConfig { return new(saml.Config) },
 }

--- a/storage/kubernetes/types.go
+++ b/storage/kubernetes/types.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	jose "gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2"
 
 	"github.com/coreos/dex/storage"
 	"github.com/coreos/dex/storage/kubernetes/k8sapi"
@@ -245,9 +245,9 @@ type Client struct {
 
 // ClientList is a list of Clients.
 type ClientList struct {
-	k8sapi.TypeMeta `json:",inline"`
-	k8sapi.ListMeta `json:"metadata,omitempty"`
-	Clients         []Client `json:"items"`
+	k8sapi.TypeMeta  `json:",inline"`
+	k8sapi.ListMeta  `json:"metadata,omitempty"`
+	Clients []Client `json:"items"`
 }
 
 func (cli *client) fromStorageClient(c storage.Client) Client {
@@ -289,6 +289,7 @@ type Claims struct {
 	Email         string   `json:"email"`
 	EmailVerified bool     `json:"emailVerified"`
 	Groups        []string `json:"groups,omitempty"`
+	UserDN        string   `json:"user_dn,omitempty"`
 }
 
 func fromStorageClaims(i storage.Claims) Claims {
@@ -298,6 +299,7 @@ func fromStorageClaims(i storage.Claims) Claims {
 		Email:         i.Email,
 		EmailVerified: i.EmailVerified,
 		Groups:        i.Groups,
+		UserDN:        i.UserDN,
 	}
 }
 
@@ -308,6 +310,7 @@ func toStorageClaims(i Claims) storage.Claims {
 		Email:         i.Email,
 		EmailVerified: i.EmailVerified,
 		Groups:        i.Groups,
+		UserDN:        i.UserDN,
 	}
 }
 
@@ -344,9 +347,9 @@ type AuthRequest struct {
 
 // AuthRequestList is a list of AuthRequests.
 type AuthRequestList struct {
-	k8sapi.TypeMeta `json:",inline"`
-	k8sapi.ListMeta `json:"metadata,omitempty"`
-	AuthRequests    []AuthRequest `json:"items"`
+	k8sapi.TypeMeta            `json:",inline"`
+	k8sapi.ListMeta            `json:"metadata,omitempty"`
+	AuthRequests []AuthRequest `json:"items"`
 }
 
 func toStorageAuthRequest(req AuthRequest) storage.AuthRequest {
@@ -412,9 +415,9 @@ type Password struct {
 
 // PasswordList is a list of Passwords.
 type PasswordList struct {
-	k8sapi.TypeMeta `json:",inline"`
-	k8sapi.ListMeta `json:"metadata,omitempty"`
-	Passwords       []Password `json:"items"`
+	k8sapi.TypeMeta      `json:",inline"`
+	k8sapi.ListMeta      `json:"metadata,omitempty"`
+	Passwords []Password `json:"items"`
 }
 
 func (cli *client) fromStoragePassword(p storage.Password) Password {
@@ -467,9 +470,9 @@ type AuthCode struct {
 
 // AuthCodeList is a list of AuthCodes.
 type AuthCodeList struct {
-	k8sapi.TypeMeta `json:",inline"`
-	k8sapi.ListMeta `json:"metadata,omitempty"`
-	AuthCodes       []AuthCode `json:"items"`
+	k8sapi.TypeMeta      `json:",inline"`
+	k8sapi.ListMeta      `json:"metadata,omitempty"`
+	AuthCodes []AuthCode `json:"items"`
 }
 
 func (cli *client) fromStorageAuthCode(a storage.AuthCode) AuthCode {
@@ -530,9 +533,9 @@ type RefreshToken struct {
 
 // RefreshList is a list of refresh tokens.
 type RefreshList struct {
-	k8sapi.TypeMeta `json:",inline"`
-	k8sapi.ListMeta `json:"metadata,omitempty"`
-	RefreshTokens   []RefreshToken `json:"items"`
+	k8sapi.TypeMeta              `json:",inline"`
+	k8sapi.ListMeta              `json:"metadata,omitempty"`
+	RefreshTokens []RefreshToken `json:"items"`
 }
 
 func toStorageRefreshToken(r RefreshToken) storage.RefreshToken {
@@ -701,7 +704,7 @@ func toStorageConnector(c Connector) storage.Connector {
 
 // ConnectorList is a list of Connectors.
 type ConnectorList struct {
-	k8sapi.TypeMeta `json:",inline"`
-	k8sapi.ListMeta `json:"metadata,omitempty"`
-	Connectors      []Connector `json:"items"`
+	k8sapi.TypeMeta        `json:",inline"`
+	k8sapi.ListMeta        `json:"metadata,omitempty"`
+	Connectors []Connector `json:"items"`
 }

--- a/storage/sql/migrate.go
+++ b/storage/sql/migrate.go
@@ -100,7 +100,9 @@ var migrations = []migration{
 				connector_id text not null,
 				connector_data bytea,
 		
-				expiry timestamptz not null
+				expiry timestamptz not null,
+
+				claims_user_dn text not null
 			);
 		
 			create table auth_code (
@@ -119,7 +121,9 @@ var migrations = []migration{
 				connector_id text not null,
 				connector_data bytea,
 		
-				expiry timestamptz not null
+				expiry timestamptz not null,
+
+				claims_user_dn text not null
 			);
 		
 			create table refresh_token (
@@ -135,7 +139,9 @@ var migrations = []migration{
 				claims_groups bytea not null, -- JSON array of strings
 		
 				connector_id text not null,
-				connector_data bytea
+				connector_data bytea,
+
+				claims_user_dn text not null
 			);
 
 			create table password (

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	jose "gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2"
 )
 
 var (
@@ -143,6 +143,8 @@ type Claims struct {
 	EmailVerified bool
 
 	Groups []string
+
+	UserDN string
 }
 
 // AuthRequest represents a OAuth2 client authorization request. It holds the state


### PR DESCRIPTION
NOTE: This PR is meant to be more for discussion than for merging in this code as it stands.

---

At @DecipherNow, we have many clients that have a sizable investment in two way SSL/TLS. Rather than having every web app authenticate via their PKI, there's an interest in moving to a setup where they can auth via PKI once to receive an OAuth/OIDC token, and then use that token to authenticate with each web app, using an `user_dn` claim to pass along the user's Distinguished Name (taken from the cert their browser presented).

The code presented in this PR represents the simplest approach I could find to make this possible, so there are some obvious changes (in the works) e.g. to make corresponding changes to the config options, etc. I'm currently abusing the `PasswordConnector`, as it was easier to implement this while making minimal changes to the existing code, and allowing the (existing) types to guide the implementation.

With those warts aside, there's still the open question: what to do about custom claims (e.g. `user_dn`)? 
Adding the `user_dn` claim required touching a number of `struct`s and tweaking the tables/queries In the SQL backend (`storage/sql/crud.go`).

**TL;DR: Would there be interest in an architectural change that would allow for each of the backends supporting any arbitrary set of (potentially user defined) claims?** If so, @DecipherNow would like to allocate resources to make the required changes.

If that's something that we could upstream, I'd love to chat about how to proceed design-wise - whether here, IRC, Slack, or whatever works best for you.