### PR TITLE
Update check go major version way

### DIFF
--- a/scripts/check-go-version
+++ b/scripts/check-go-version
@@ -5,7 +5,7 @@ set -e
 VERSION=$( go version )
 
 # For development versions of Go, these will be empty.
-MAJOR_GOVERSION=$( echo -n "$VERSION" | grep -o 'go1\.[0-9]' || true )
+MAJOR_GOVERSION=$( echo -n "$VERSION" | grep -o 'go1\.[0-9]*' || true )
 FULL_GOVERSION=$( echo -n "$VERSION" | grep -o 'go1\.[0-9|\.]*' || true )
 
 # The list of unsupported major go versions.


### PR DESCRIPTION
the current way  just keeps one prefix number as the major number, it should be the whole number after the dot.

for now, if make executed, go 1.10 will be reported **unsupported**