### PR TITLE
Evaluate symlinks when loading templates

### DIFF
--- a/server/templates.go
+++ b/server/templates.go
@@ -126,6 +126,18 @@ func loadTemplates(c webConfig, templatesDir string) (*templates, error) {
 
 	filenames := []string{}
 	for _, file := range files {
+		if file.Mode()&os.ModeSymlink > 0 {
+			var err error
+			fp := filepath.Join(templatesDir, file.Name())
+			fp, err = filepath.EvalSymlinks(fp)
+			if err != nil {
+				return nil, fmt.Errorf("evaluate symlink: %v", err)
+			}
+			file, err = os.Stat(fp)
+			if err != nil {
+				return nil, fmt.Errorf("retrieve file info: %v", err)
+			}
+		}
 		if file.IsDir() {
 			continue
 		}

--- a/server/templates_test.go
+++ b/server/templates_test.go
@@ -1,1 +1,54 @@
 package server
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestTemplatesCheckSymlinkDirs(t *testing.T) {
+	templateDir, err := createTemplates()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := webConfig{}
+	_, err = loadTemplates(c, templateDir)
+
+	if err != nil {
+		t.Errorf("expected err to not have ocurred, got %q", err)
+	}
+}
+
+// createTemplates creates a directory structure containing empty templates using symlinks to folders and files, e.g.:
+// templateDir
+// ├── ..data          -> ..actual
+// ├── ..approval.html -> ..data/approval.html
+// └── ..actual
+// 	   └── approval.html
+func createTemplates() (string, error) {
+	templateDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return "", err
+	}
+	actualDir := join(templateDir, "..actual")
+	symlinkDir := join(templateDir, "..data")
+	if err = os.Mkdir(actualDir, 0755); err != nil {
+		return "", err
+	}
+	if err = os.Symlink(actualDir, symlinkDir); err != nil {
+		return "", err
+	}
+	for _, template := range requiredTmpls {
+		templatePath := join(templateDir, template)
+		symlinkTemplate := join(symlinkDir, template)
+		actualTemplate := join(actualDir, template)
+		if err = ioutil.WriteFile(actualTemplate, []byte(template), 0444); err != nil {
+			return "", err
+		}
+		if err = os.Symlink(symlinkTemplate, templatePath); err != nil {
+			return "", err
+		}
+	}
+	return templateDir, nil
+}


### PR DESCRIPTION
to avoid considering a symlinked directory as a file.

It correctly processes a structure like:
```
templates
├── ..data  ->  ..actual
├── ..approval.html  ->  ..data/approval
└── ..actual
        └── approval.html
```
whereas before it failed with the error:
`failed to initialize server: server: failed to load web static: parse files: read web/templates/..data: is a directory`.
