### PR TITLE
Updates go to 1.10.2 to support SHA-512 for ldaps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.0-alpine
+FROM golang:1.10.2-alpine
 
 RUN apk add --no-cache --update alpine-sdk
 


### PR DESCRIPTION
This addresses issues with connecting to AD over LDAPS where the AD server is presenting a SHA-512 certificate. This was resulting in `connection reset by peer` errors:
```
time="2018-05-10T03:09:20Z" level=error msg="Failed to login user: failed to connect: LDAP Result Code 200 \"\": read tcp 10.5.32.202:48558->10.2.4.182:636: read: connection reset by peer" 
```

See:
https://github.com/golang/go/issues/22422
https://github.com/golang/go/commit/96cd66b266a24d8ed1f66dfa10ddb86d88b50fca
